### PR TITLE
Fix run scripts to exit when Streamlit stops

### DIFF
--- a/knowledgeplus_design-main/run_app.bat
+++ b/knowledgeplus_design-main/run_app.bat
@@ -2,5 +2,4 @@
 REM Launch the unified Streamlit interface
 cd /d "%~dp0"
 streamlit run unified_app.py
-pause
 

--- a/knowledgeplus_design-main/run_app.sh
+++ b/knowledgeplus_design-main/run_app.sh
@@ -2,6 +2,4 @@
 # Launch the unified Streamlit interface
 cd "$(dirname "$0")" || exit 1
 streamlit run unified_app.py
-read -n 1 -s -r -p "Press any key to exit..."
-echo
 


### PR DESCRIPTION
## Summary
- update `run_app.sh` and `run_app.bat` so they exit automatically when Streamlit finishes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_68631a2dabd08333a6c72a330a32b466