### PR TITLE
Update README with font instructions

### DIFF
--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -20,6 +20,10 @@ export OPENAI_API_KEY=your_api_key_here
 set OPENAI_API_KEY=your_api_key_here
 ```
 
+### IPAexGothicフォント
+
+PDFエクスポートには日本語フォント `ipaexg.ttf` が必要です。<https://moji.or.jp/ipafont/> からダウンロードし、リポジトリのルートに配置してください。フォントが無い場合、エクスポートは失敗します。
+
 ### アプリケーションの起動
 
 ```bash


### PR DESCRIPTION
## Summary
- mention required IPAexGothic font download in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68636fa5dd048333bae1ebe8d10c800d