### PR TITLE
Update README with HuggingFace mirror note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A simple Streamlit prototype for uploading files, creating a knowledge base and 
 * Launch the app with:
 
   ```bash
-  ./knowledgeplus_design-main/run_app.sh
-  ```
+./knowledgeplus_design-main/run_app.sh
+```
+
+If you require model files that are normally fetched from HuggingFace, be aware
+that this environment blocks direct downloads from that service. Retrieve the
+same files from a mirror or copy them locally before launching the app.
 


### PR DESCRIPTION
## Summary
- mention that this environment blocks direct access to HuggingFace
- advise fetching needed models from a mirror before running the app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_6863714d41a08333a1d75fcb93b4f684