### PR TITLE
Fix quoting in tests

### DIFF
--- a/knowledgeplus_design-main/tests/test_read_file.py
+++ b/knowledgeplus_design-main/tests/test_read_file.py
@@ -7,6 +7,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 pytest.importorskip("streamlit")
+pytest.importorskip("sudachipy")
 
 
 

--- a/knowledgeplus_design-main/tests/test_search_engine.py
+++ b/knowledgeplus_design-main/tests/test_search_engine.py
@@ -51,11 +51,11 @@ def temp_kb_with_data(tmp_path):
     }
 
     for chunk in dummy_chunks:
-        with open(chunks_path / f"{chunk["id"]}.txt", "w", encoding="utf-8") as f:
+        with open(chunks_path / f"{chunk['id']}.txt", "w", encoding="utf-8") as f:
             f.write(chunk["text"])
-        with open(metadata_path / f"{chunk["id"]}.json", "w", encoding="utf-8") as f:
+        with open(metadata_path / f"{chunk['id']}.json", "w", encoding="utf-8") as f:
             json.dump(chunk["metadata"], f)
-        with open(embeddings_path / f"{chunk["id"]}.pkl", "wb") as f:
+        with open(embeddings_path / f"{chunk['id']}.pkl", "wb") as f:
             import pickle
             pickle.dump({'embedding': dummy_embeddings[chunk["id"]]}, f)
             

--- a/knowledgeplus_design-main/tests/test_unified_app.py
+++ b/knowledgeplus_design-main/tests/test_unified_app.py
@@ -32,6 +32,7 @@ def test_manual_refresh_call_present():
 
 def test_safe_generate_handles_error(monkeypatch):
     pytest.importorskip('streamlit')
+    pytest.importorskip('sudachipy')
 
     import streamlit as st
     # Mock st.error to capture its calls
@@ -77,6 +78,7 @@ def test_safe_generate_handles_error(monkeypatch):
 
 def test_refresh_search_engine_reloads_engine(monkeypatch):
     pytest.importorskip('streamlit')
+    pytest.importorskip('sudachipy')
     import streamlit as st
     
     # Mock st.session_state


### PR DESCRIPTION
## Summary
- fix quoting for chunk IDs when writing test fixtures
- skip tests that require `sudachipy` when it's missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863cac0492c8333b3d2da918f7a40b4