### PR TITLE
Add env example and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple Streamlit prototype for uploading files, creating a knowledge base and 
 
 * Read the [full setup guide](knowledgeplus_design-main/README.md) for details.
 * Install packages with `pip install -r knowledgeplus_design-main/requirements-light.txt` for the basics.
-* Set the OpenAI key before starting:
+* Copy `knowledgeplus_design-main/.env.example` to `.env` and set the OpenAI key before starting:
 
   ```bash
   export OPENAI_API_KEY=your_api_key

--- a/knowledgeplus_design-main/.env.example
+++ b/knowledgeplus_design-main/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=your_api_key_here

--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -29,6 +29,8 @@ pip install rank-bm25==0.2.2
 
 環境変数 `OPENAI_API_KEY` にAPIキーを設定してください。
 
+まずはサンプルの `.env.example` を `.env` にコピーし、値を書き換えても構いません。
+
 ```bash
 export OPENAI_API_KEY=your_api_key_here
 # またはWindowsの場合


### PR DESCRIPTION
## Summary
- add `.env.example` with a sample `OPENAI_API_KEY`
- update root setup steps to copy the example file
- mention `.env.example` in the detailed README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863d28d20a08333a9d43d39ad6577bc