### PR TITLE
Add tests for chat history utils

### DIFF
--- a/knowledgeplus_design-main/tests/test_chat_history_utils.py
+++ b/knowledgeplus_design-main/tests/test_chat_history_utils.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from shared import chat_history_utils as chu
+
+
+def test_chat_history_lifecycle(tmp_path, monkeypatch):
+    monkeypatch.setattr(chu, "CHAT_HISTORY_DIR", tmp_path)
+    tmp_path.mkdir(exist_ok=True)
+    hid = chu.create_history({"mode": "test"})
+    chu.append_message(hid, "user", "hello")
+    chu.append_message(hid, "assistant", "hi")
+    chu.update_title(hid, "Session")
+    data = json.loads((tmp_path / f"{hid}.json").read_text(encoding="utf-8"))
+    assert data["title"] == "Session"
+    assert data["settings"] == {"mode": "test"}
+    assert len(data["messages"]) == 2
+
+    histories = chu.load_chat_histories()
+    assert len(histories) == 1
+    h = histories[0]
+    assert h["id"] == hid
+    assert h["title"] == "Session"
+    assert h["settings"] == {"mode": "test"}
+    assert len(h["messages"]) == 2


### PR DESCRIPTION
## Summary
- add a unit test for chat history utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f164e8ac8333bdd41044c5482091