### PR TITLE
Refine unified app styling

### DIFF
--- a/knowledgeplus_design-main/tests/test_theme_call.py
+++ b/knowledgeplus_design-main/tests/test_theme_call.py
@@ -22,3 +22,8 @@ def test_mm_kb_theme_call_uses_arg():
 def test_gpt_app_theme_call_uses_arg():
     app_path = PROJECT_ROOT / 'knowledge_gpt_app' / 'app.py'
     assert _get_theme_call_args(str(app_path)) == 1
+
+
+def test_unified_app_theme_call_uses_arg():
+    app_path = PROJECT_ROOT / 'unified_app.py'
+    assert _get_theme_call_args(str(app_path)) == 1

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -8,6 +8,7 @@ from shared.chat_controller import ChatController, get_persona_list
 from shared.search_engine import HybridSearchEngine
 from shared.file_processor import FileProcessor
 from shared.upload_utils import ensure_openai_key, BASE_KNOWLEDGE_DIR
+from ui_modules.theme import apply_intel_theme
 from shared.chat_history_utils import (
     load_chat_histories,
     create_history,
@@ -43,6 +44,8 @@ except Exception as e:
 st.set_page_config(
     layout="wide", page_title="KNOWLEDGE+", initial_sidebar_state="collapsed"
 )
+
+apply_intel_theme(st)
 
 st.markdown("""
 <style>


### PR DESCRIPTION
## Summary
- apply common Intel theme in unified_app
- check for theme calls in unified_app tests

## Testing
- `pytest knowledgeplus_design-main/tests/test_theme_call.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_6863f6dbcd608333b3777ba54fb31875