### PR TITLE
Refactor chat history path

### DIFF
--- a/knowledgeplus_design-main/shared/chat_history_utils.py
+++ b/knowledgeplus_design-main/shared/chat_history_utils.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
-CHAT_HISTORY_DIR = Path(__file__).resolve().parent.parent / "chat_history"
+# Store histories at the repository root so they are shared across all apps
+CHAT_HISTORY_DIR = Path(__file__).resolve().parents[2] / "chat_history"
 CHAT_HISTORY_DIR.mkdir(parents=True, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- store chat histories under the repository root so all apps share the same location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686401e724d083338ab168c77246454e