### PR TITLE
Refactor sidebar prompt advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A simple Streamlit prototype for uploading files, creating a knowledge base and 
 
 * Read the [full setup guide](knowledgeplus_design-main/README.md) for details.
 * Install packages with `pip install -r knowledgeplus_design-main/requirements-light.txt` for the basics.
+* Add advanced features later with `pip install -r knowledgeplus_design-main/requirements-extra.txt`.
 * Copy `knowledgeplus_design-main/.env.example` to `.env` and set the OpenAI key before starting:
 
   ```bash

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -320,8 +320,11 @@ with st.sidebar.expander("チャット設定", expanded=False):
     st.session_state.temperature = st.slider(
         "温度", 0.0, 1.0, float(st.session_state.get("temperature", 0.7)), 0.05
     )
+
+with st.sidebar.expander("プロンプトアドバイス", expanded=False):
     st.session_state.prompt_advice = st.checkbox(
-        "アドバイスを有効化", value=st.session_state.get("prompt_advice", False)
+        "アドバイスを有効化",
+        value=st.session_state.get("prompt_advice", False),
     )
 
 # --- Main Content Area based on Mode ---


### PR DESCRIPTION
## Summary
- expose prompt advice in its own sidebar expander
- clarify that heavy dependencies can be installed separately

## Testing
- `pip install -r requirements-light.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686473f120c48333820d9fdc05380f9a