### PR TITLE
Update knowledge base path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ A simple Streamlit prototype for uploading files, creating a knowledge base and 
   export OPENAI_API_KEY=your_api_key
   ```
 
+You can also override the default `knowledge_base/` directory location by setting `KNOWLEDGE_BASE_DIR` before running the app:
+
+  ```bash
+  export KNOWLEDGE_BASE_DIR=/path/to/storage
+  ```
+
 * Launch the app with:
 
   ```bash

--- a/knowledgeplus_design-main/shared/upload_utils.py
+++ b/knowledgeplus_design-main/shared/upload_utils.py
@@ -1,11 +1,12 @@
-import os
 import json
 import pickle
+import os
 from pathlib import Path
 from typing import Dict, Any
 
-# Base directory for all knowledge bases
-BASE_KNOWLEDGE_DIR = Path(__file__).resolve().parent.parent / "knowledge_base"
+# Base directory for all knowledge bases. Allow override via environment variable
+_default_base = Path(__file__).resolve().parent.parent / "knowledge_base"
+BASE_KNOWLEDGE_DIR = Path(os.getenv("KNOWLEDGE_BASE_DIR", _default_base))
 BASE_KNOWLEDGE_DIR.mkdir(parents=True, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- allow custom knowledge base directory via `KNOWLEDGE_BASE_DIR`
- document the new environment variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686476e079c0833396e2bb7f418386f6