### PR TITLE
Implement prompt advisor helper

### DIFF
--- a/knowledgeplus_design-main/shared/prompt_advisor.py
+++ b/knowledgeplus_design-main/shared/prompt_advisor.py
@@ -1,0 +1,38 @@
+import logging
+from typing import Optional
+from openai import OpenAI
+
+from .upload_utils import ensure_openai_key
+
+logger = logging.getLogger(__name__)
+
+# Lightweight model for prompt advice generation
+PROMPT_ADVICE_MODEL = "gpt-4o-mini"
+
+
+def generate_prompt_advice(user_prompt: str, client: Optional[OpenAI] = None) -> Optional[str]:
+    """Return improved prompt suggestions using a lightweight GPT model."""
+    if not user_prompt:
+        return None
+    if client is None:
+        try:
+            api_key = ensure_openai_key()
+            client = OpenAI(api_key=api_key)
+        except Exception as e:  # pragma: no cover - env misconfig
+            logger.error(f"OpenAI client init failed: {e}")
+            return None
+
+    try:
+        resp = client.chat.completions.create(
+            model=PROMPT_ADVICE_MODEL,
+            messages=[
+                {"role": "system", "content": "ユーザープロンプトを明確にするアドバイスを日本語で箇条書きで返してください。"},
+                {"role": "user", "content": f"以下のプロンプトを改善してください:\n\n---\n{user_prompt}\n---"},
+            ],
+            temperature=0.0,
+            max_tokens=400,
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception as e:  # pragma: no cover - API failure
+        logger.error(f"Prompt advice generation error: {e}", exc_info=True)
+        return None

--- a/knowledgeplus_design-main/tests/test_prompt_advisor.py
+++ b/knowledgeplus_design-main/tests/test_prompt_advisor.py
@@ -1,0 +1,24 @@
+import types
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from shared.prompt_advisor import generate_prompt_advice
+
+class MockClient:
+    def __init__(self, text):
+        self._text = text
+        self.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(
+                create=lambda **k: types.SimpleNamespace(
+                    choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=self._text))]
+                )
+            )
+        )
+
+def test_generate_prompt_advice_returns_text():
+    client = MockClient("- improved")
+    result = generate_prompt_advice("hello", client=client)
+    assert result == "- improved"

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -30,6 +30,7 @@ from knowledge_gpt_app.app import (
 from generate_faq import generate_faqs_from_chunks
 
 from config import DEFAULT_KB_NAME
+from shared.prompt_advisor import generate_prompt_advice
 
 logger = logging.getLogger(__name__)
 
@@ -478,19 +479,9 @@ if st.session_state["current_mode"] == "チャット":
         if st.session_state.get("prompt_advice"):
             client = get_openai_client()
             if client:
-                advice_gen = safe_generate_gpt_response(
-                    f"以下のユーザープロンプトを、より明確で効果的なプロンプトにするための改善案を、簡潔な箇条書きのMarkdown形式で提案してください:\n\n---\n{user_msg}\n---",
-                    conversation_history=[],
-                    persona="default",
-                    temperature=0.0,
-                    response_length="簡潔",
-                    client=client,
-                )
-                advice_text = ""
-                if advice_gen:
-                    for chunk in advice_gen:
-                        advice_text += chunk
-                st.info(f"💡 プロンプトアドバイス:\n{advice_text}")
+                advice_text = generate_prompt_advice(user_msg, client=client)
+                if advice_text:
+                    st.info(f"💡 プロンプトアドバイス:\n{advice_text}")
         
         context = ""
         if use_kb:


### PR DESCRIPTION
## Summary
- add `prompt_advisor` helper to centralize prompt improvement generation
- integrate prompt advisor into `unified_app`
- test new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a72136448333959d39f4ed564081