### PR TITLE
Add helper scripts for split dependency installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A simple Streamlit prototype for uploading files, creating a knowledge base and 
 * Read the [full setup guide](knowledgeplus_design-main/README.md) for details.
 * Install packages with `pip install -r knowledgeplus_design-main/requirements-light.txt` for the basics.
 * Add advanced features later with `pip install -r knowledgeplus_design-main/requirements-extra.txt`.
+* Alternatively run `scripts/install_light.sh` or `scripts/install_full.sh` to install the minimal or full set in two steps.
 * Copy `knowledgeplus_design-main/.env.example` to `.env` and set the OpenAI key before starting:
 
   ```bash

--- a/scripts/install_full.sh
+++ b/scripts/install_full.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Install minimal and extra dependencies separately to avoid heavy downloads in one step
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+pip install -r "$REPO_ROOT/knowledgeplus_design-main/requirements-light.txt"
+pip install -r "$REPO_ROOT/knowledgeplus_design-main/requirements-extra.txt"

--- a/scripts/install_light.sh
+++ b/scripts/install_light.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Install minimal dependencies
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+pip install -r "$REPO_ROOT/knowledgeplus_design-main/requirements-light.txt"


### PR DESCRIPTION
## Summary
- add helper scripts `install_light.sh` and `install_full.sh`
- reference the new scripts in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c3a22b008333be8c0c6e31ed10f8