### PR TITLE
Refactor document card UI helper

### DIFF
--- a/knowledgeplus_design-main/tests/test_document_card.py
+++ b/knowledgeplus_design-main/tests/test_document_card.py
@@ -1,0 +1,20 @@
+import importlib
+import pytest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+pytest.importorskip("streamlit")
+import streamlit as st
+
+
+def test_render_document_card_outputs_html(monkeypatch):
+    outputs = []
+    monkeypatch.setattr(st, "markdown", lambda text, unsafe_allow_html=False: outputs.append(text))
+    mod = importlib.import_module("ui_modules.document_card")
+    doc = {"metadata": {"title": "foo"}, "text": "hello world", "similarity": 0.5}
+    mod.render_document_card(doc)
+    assert outputs
+    assert "foo" in outputs[0]
+    assert "Score" in outputs[0]

--- a/knowledgeplus_design-main/ui_modules/document_card.py
+++ b/knowledgeplus_design-main/ui_modules/document_card.py
@@ -1,0 +1,17 @@
+import streamlit as st
+from html import escape
+from typing import Dict, Any
+
+
+def render_document_card(doc: Dict[str, Any]) -> None:
+    """Display a single search result using the `doc-card` style."""
+    meta = doc.get("metadata", {}) or {}
+    display_meta = meta.get("display_metadata", {}) or {}
+    title = meta.get("title") or display_meta.get("title") or meta.get("filename", "No title")
+    snippet = doc.get("text", "")[:120].replace("\n", " ")
+    similarity = doc.get("similarity")
+    body = f"<div class='doc-card'><strong>{escape(title)}</strong>"
+    if similarity is not None:
+        body += f"<div>Score: {similarity:.3f}</div>"
+    body += f"<div>{escape(snippet)}...</div></div>"
+    st.markdown(body, unsafe_allow_html=True)

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -174,6 +174,7 @@ h1 {
 """, unsafe_allow_html=True)
 
 from ui_modules.sidebar_toggle import render_sidebar_toggle
+from ui_modules.document_card import render_document_card
 
 TOGGLE_SIDEBAR_KEY = "toggle_sidebar"
 TOGGLE_SIDEBAR_COLLAPSED = ">>"
@@ -201,21 +202,6 @@ def safe_generate_gpt_response(user_input, conversation_history=None, persona="d
         st.error(f"GPT応答生成エラー: {e}")
         logger.error("GPT response generation error", exc_info=True)
         return None
-
-
-def render_document_card(doc: dict) -> None:
-    """Display a single search result using the `doc-card` style."""
-    meta = doc.get("metadata", {}) or {}
-    display_meta = meta.get("display_metadata", {}) or {}
-    title = meta.get("title") or display_meta.get("title") or meta.get("filename", "No title")
-    snippet = doc.get("text", "")[:120].replace("\n", " ")
-    similarity = doc.get("similarity")
-    from html import escape
-    body = f"<div class='doc-card'><strong>{escape(title)}</strong>"
-    if similarity is not None:
-        body += f"<div>Score: {similarity:.3f}</div>"
-    body += f"<div>{escape(snippet)}...</div></div>"
-    st.markdown(body, unsafe_allow_html=True)
 
 # --- Session State Initialization ---
 if "current_mode" not in st.session_state:


### PR DESCRIPTION
## Summary
- move `render_document_card` from `unified_app.py` into `ui_modules`
- adjust imports and add minimal `__init__`
- cover the new helper with unit test

## Testing
- `pip install -r requirements-light.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c5075f508333945625d4629169ca