### PR TITLE
Load env file at startup

### DIFF
--- a/knowledgeplus_design-main/shared/env.py
+++ b/knowledgeplus_design-main/shared/env.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Environment utilities for loading configuration."""
+
+from pathlib import Path
+from dotenv import load_dotenv
+
+_env_loaded = False
+
+
+def load_env(path: str | Path | None = None) -> None:
+    """Load environment variables from a .env file once."""
+    global _env_loaded
+    if _env_loaded:
+        return
+
+    env_path = Path(path) if path else Path(__file__).resolve().parents[2] / ".env"
+    if env_path.exists():
+        load_dotenv(env_path)
+    _env_loaded = True


### PR DESCRIPTION
## Summary
- add `shared/env.py` helper to load a `.env` file
- call `load_env()` from `unified_app.py`
- guard sidebar calls in `unified_app.py` so tests can monkeypatch `st.sidebar`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864cfb4974c83339bcf6f1111a813f5