### PR TITLE
Centralize logging setup

### DIFF
--- a/knowledgeplus_design-main/knowledge_gpt_app/app.py
+++ b/knowledgeplus_design-main/knowledge_gpt_app/app.py
@@ -56,17 +56,11 @@ from shared.upload_utils import (
 )
 from generate_faq import generate_faqs_from_chunks
 from ui_modules.theme import apply_intel_theme
+from shared.logging_utils import configure_logging
 
 # ロギング設定を最初に行う
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler("rag_tool.log", encoding='utf-8'),
-        logging.StreamHandler(),
-    ],
-)
-logger = logging.getLogger("rag_tool")
+configure_logging()
+logger = logging.getLogger(__name__)
 
 # スクリプトディレクトリの解決
 current_dir = Path(__file__).resolve().parent

--- a/knowledgeplus_design-main/mm_kb_builder/app.py
+++ b/knowledgeplus_design-main/mm_kb_builder/app.py
@@ -13,6 +13,7 @@ from shared.upload_utils import (
 from shared.file_processor import FileProcessor
 from shared.kb_builder import KnowledgeBuilder
 from ui_modules.theme import apply_intel_theme
+from shared.logging_utils import configure_logging
 
 def _refresh_search_engine(kb_name: str) -> None:
     """Dynamically import and call refresh_search_engine to avoid circular imports."""
@@ -54,11 +55,8 @@ if str(repo_root) not in sys.path:
     sys.path.insert(0, str(repo_root))
 
 # ロギング設定
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger('multimodal_kb_builder')
+configure_logging()
+logger = logging.getLogger(__name__)
 
 # 定数
 GPT4O_MODEL = "gpt-4.1"

--- a/knowledgeplus_design-main/shared/logging_utils.py
+++ b/knowledgeplus_design-main/shared/logging_utils.py
@@ -1,0 +1,32 @@
+"""Logging utilities shared by the Streamlit apps."""
+
+import logging
+from logging import FileHandler, StreamHandler, Formatter
+
+
+def configure_logging(log_file: str = "rag_tool.log", level: int = logging.INFO) -> None:
+    """Configure the root logger once with uniform handlers.
+
+    Parameters
+    ----------
+    log_file : str
+        Path to the file where logs will be written.
+    level : int
+        Logging level for the root logger.
+    """
+
+    root = logging.getLogger()
+    if root.handlers:
+        return
+
+    root.setLevel(level)
+    fmt = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    formatter = Formatter(fmt)
+
+    file_handler = FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    stream_handler = StreamHandler()
+    stream_handler.setFormatter(formatter)
+
+    root.addHandler(file_handler)
+    root.addHandler(stream_handler)


### PR DESCRIPTION
## Summary
- add a `shared.logging_utils` helper
- use `configure_logging()` in the Streamlit apps
- revert logging changes to an unused legacy script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for streamlit, openai, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6864dc6fbb088333912035f4b48d8530