### PR TITLE
Add extra dependency install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple Streamlit prototype for uploading files, creating a knowledge base and 
 * Read the [full setup guide](knowledgeplus_design-main/README.md) for details.
 * Install packages with `pip install -r knowledgeplus_design-main/requirements-light.txt` for the basics.
 * Add advanced features later with `pip install -r knowledgeplus_design-main/requirements-extra.txt`.
-* Alternatively run `scripts/install_light.sh` or `scripts/install_full.sh` to install the minimal or full set in two steps.
+* Alternatively run `scripts/install_light.sh` for the basics, `scripts/install_extra.sh` when you need the heavy libraries, or `scripts/install_full.sh` to install everything in one go.
 * Copy `knowledgeplus_design-main/.env.example` to `.env` and set the OpenAI key before starting:
 
   ```bash

--- a/scripts/install_extra.sh
+++ b/scripts/install_extra.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Install only the heavier optional dependencies
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+pip install -r "$REPO_ROOT/knowledgeplus_design-main/requirements-extra.txt"


### PR DESCRIPTION
## Summary
- add `install_extra.sh` for optional heavy packages
- mention new script in installation instructions

## Testing
- `bash scripts/install_light.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651958d92c83339be609158eb53e20