### PR TITLE
Add prompt advice history tracking

### DIFF
--- a/knowledgeplus_design-main/tests/test_unified_app.py
+++ b/knowledgeplus_design-main/tests/test_unified_app.py
@@ -50,6 +50,12 @@ def test_delete_history_button_present():
     assert '削除' in text
 
 
+def test_prompt_advice_saved_to_history():
+    app_path = PROJECT_ROOT / 'unified_app.py'
+    text = app_path.read_text(encoding='utf-8')
+    assert 'append_message(st.session_state.current_chat_id, "info", advice_text)' in text
+
+
 def test_safe_generate_handles_error(monkeypatch):
     pytest.importorskip('streamlit')
     pytest.importorskip('sudachipy')

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -506,6 +506,8 @@ if st.session_state["current_mode"] == "チャット":
                 advice_text = generate_prompt_advice(user_msg, client=client)
                 if advice_text:
                     st.info(f"💡 プロンプトアドバイス:\n{advice_text}")
+                    st.session_state["chat_history"].append({"role": "info", "content": advice_text})
+                    append_message(st.session_state.current_chat_id, "info", advice_text)
         
         context = ""
         if use_kb:


### PR DESCRIPTION
## Summary
- capture prompt advice inside chat history
- assert advice persistence in unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865b436eb80833397ab2fca41bbec5d