### PR TITLE
Implement chat history path override

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ You can also override the default `knowledge_base/` directory location by settin
   export KNOWLEDGE_BASE_DIR=/path/to/storage
   ```
 
+You can similarly override where chat histories are stored by setting
+`CHAT_HISTORY_DIR`:
+
+  ```bash
+  export CHAT_HISTORY_DIR=/path/to/chat_history
+  ```
+
 * Launch the app with:
 
   ```bash

--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -53,6 +53,8 @@ streamlit run app.py
 
 アップロードされたファイルや生成されたデータは `knowledge_base/<kb_name>` 以下に保存されます。デフォルトのナレッジベース名は `config.py` の `DEFAULT_KB_NAME` で定義されています。
 
+保存先ディレクトリを変更したい場合は `KNOWLEDGE_BASE_DIR` 環境変数を、チャット履歴の保存場所を変更したい場合は `CHAT_HISTORY_DIR` を設定してください。
+
 ## ✨ 主な機能
 
 *   **検索中心のUI**: Googleのようなシンプルで直感的なインターフェースで、必要な情報に素早くアクセスできます。

--- a/knowledgeplus_design-main/shared/chat_history_utils.py
+++ b/knowledgeplus_design-main/shared/chat_history_utils.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
-# Store histories at the repository root so they are shared across all apps
-CHAT_HISTORY_DIR = Path(__file__).resolve().parents[2] / "chat_history"
+# Store histories at the repository root so they are shared across all apps.
+# Allow override via the ``CHAT_HISTORY_DIR`` environment variable so the
+# location can be customized for different deployments.
+CHAT_HISTORY_DIR = Path(
+    os.getenv(
+        "CHAT_HISTORY_DIR",
+        str(Path(__file__).resolve().parents[2] / "chat_history"),
+    )
+)
 CHAT_HISTORY_DIR.mkdir(parents=True, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- allow customizing chat history location via `CHAT_HISTORY_DIR`
- document the new env var in both READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b9df694883338194f53fa7c8c7dd