### PR TITLE
Update testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ same files from a mirror or copy them locally before launching the app.
 
 ## Testing
 
+Before running `pytest`, install the test dependencies:
+
+```bash
+pip install -r knowledgeplus_design-main/requirements-light.txt
+# If you need optional features
+pip install -r knowledgeplus_design-main/requirements-extra.txt
+```
+
 Run the automated tests after installing the light requirements. Execute from the
 repository root:
 


### PR DESCRIPTION
## Summary
- remind users to install requirements before running tests

## Testing
- `pip install -r knowledgeplus_design-main/requirements-light.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c5707c8c8333b1109dddc5a9f4e3