### PR TITLE
Switch CLI scripts to logging

### DIFF
--- a/knowledgeplus_design-main/generate_faq.py
+++ b/knowledgeplus_design-main/generate_faq.py
@@ -3,8 +3,12 @@ import json
 import os
 from pathlib import Path
 from uuid import uuid4
+import logging
 
 from shared.upload_utils import BASE_KNOWLEDGE_DIR, save_processed_data
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 try:
     from openai import OpenAI
@@ -83,7 +87,7 @@ def main(argv=None):
     parser.add_argument("--pairs", type=int, default=3)
     args = parser.parse_args(argv)
     count = generate_faqs_from_chunks(args.kb_name, args.max_tokens, args.pairs)
-    print(f"Generated {count} FAQ entries")
+    logger.info("Generated %s FAQ entries", count)
 
 
 if __name__ == "__main__":

--- a/knowledgeplus_design-main/reindex_kb.py
+++ b/knowledgeplus_design-main/reindex_kb.py
@@ -1,6 +1,10 @@
 import argparse
 from pathlib import Path
+import logging
 from shared.search_engine import HybridSearchEngine
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -19,7 +23,7 @@ def main():
 
     engine = HybridSearchEngine(str(kb_path))
     engine.reindex()
-    print(f"Reindex complete for '{args.kb_name}'")
+    logger.info("Reindex complete for '%s'", args.kb_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch `reindex_kb.py` and `generate_faq.py` from `print` to `logging`
- initialise a module logger so completion messages go to the log

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865cff3a90c8333b7d4cff1e9161965