### PR TITLE
Fix thumbnail editor test helper

### DIFF
--- a/knowledgeplus_design-main/tests/test_thumbnail_editor.py
+++ b/knowledgeplus_design-main/tests/test_thumbnail_editor.py
@@ -26,6 +26,7 @@ def _create_items(tmp_dir: Path, count: int):
     for i in range(count):
         cid = str(i)
         text = f"text {i} for testing"
+        texts.append(text)
         paths = upload_utils.save_processed_data(
             kb,
             cid,


### PR DESCRIPTION
## Summary
- track generated text snippets in `tests/test_thumbnail_editor.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d883db588333a4a7c92c31441cf3