### PR TITLE
Add unit test for user metadata handling

### DIFF
--- a/knowledgeplus_design-main/docs/progress.md
+++ b/knowledgeplus_design-main/docs/progress.md
@@ -9,3 +9,7 @@
 - Implemented sidebar toggle in `unified_app.py` so the sidebar slides in and out using `<<` and `>>`.
 - Verified automated tests still pass.
 
+
+## 2025-07-03
+- Added unit test for `save_user_metadata` to verify metadata files are stored correctly.
+- All tests continue to pass with `pytest -q`.

--- a/knowledgeplus_design-main/tests/test_upload_utils.py
+++ b/knowledgeplus_design-main/tests/test_upload_utils.py
@@ -47,3 +47,10 @@ def test_save_processed_data_version(tmp_path, monkeypatch):
         original_bytes=b"b",
     )
     assert Path(third["original_file_path"]) != Path(first["original_file_path"])
+
+def test_save_user_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    path = upload_utils.save_user_metadata("kb", "abc123", "Title", ["x", "y"])
+    assert Path(path).exists()
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    assert data == {"title": "Title", "tags": ["x", "y"]}


### PR DESCRIPTION
## Summary
- add a test verifying `save_user_metadata`
- document latest progress in `progress.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865efae56388333b2185832315f853f