### PR TITLE
Add conversation title test

### DIFF
--- a/knowledgeplus_design-main/tests/test_chat_controller.py
+++ b/knowledgeplus_design-main/tests/test_chat_controller.py
@@ -1,0 +1,30 @@
+import types
+from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from shared.chat_controller import ChatController
+
+class DummyClient:
+    def __init__(self, text: str):
+        self._text = text
+        self.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(
+                create=lambda **k: types.SimpleNamespace(
+                    choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=self._text))]
+                )
+            )
+        )
+
+
+def test_generate_conversation_title_strips_quotes():
+    controller = ChatController(None)  # type: ignore[arg-type]
+    client = DummyClient("「Session Title」")
+    title = controller.generate_conversation_title(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ],
+        client=client,
+    )
+    assert title == "Session Title"


### PR DESCRIPTION
## Summary
- add unit test for ChatController.generate_conversation_title

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f28284808333948365736e807c5d