### PR TITLE
Add thumbnail metadata UI integration

### DIFF
--- a/knowledgeplus_design-main/docs/progress.md
+++ b/knowledgeplus_design-main/docs/progress.md
@@ -13,3 +13,8 @@
 ## 2025-07-03
 - Added unit test for `save_user_metadata` to verify metadata files are stored correctly.
 - All tests continue to pass with `pytest -q`.
+
+## 2025-07-04
+- Integrated thumbnail metadata editor into the management tab using `display_thumbnail_grid`.
+- Added regression test to confirm the call is present in `unified_app.py`.
+- All tests pass with `pytest -q`.

--- a/knowledgeplus_design-main/tests/test_unified_app.py
+++ b/knowledgeplus_design-main/tests/test_unified_app.py
@@ -145,3 +145,9 @@ def test_refresh_search_engine_reloads_engine(monkeypatch):
 
     # Assert that reindex was called on the correct engine instance
     assert st.session_state.search_engines[DEFAULT_KB_NAME].reindex_called
+
+
+def test_thumbnail_grid_call_present():
+    app_path = PROJECT_ROOT / 'unified_app.py'
+    text = app_path.read_text(encoding='utf-8')
+    assert 'display_thumbnail_grid(DEFAULT_KB_NAME)' in text

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -181,6 +181,7 @@ h1 {
 
 from ui_modules.sidebar_toggle import render_sidebar_toggle
 from ui_modules.document_card import render_document_card
+from ui_modules.thumbnail_editor import display_thumbnail_grid
 
 TOGGLE_SIDEBAR_KEY = "toggle_sidebar"
 TOGGLE_SIDEBAR_COLLAPSED = "＞＞"
@@ -463,6 +464,9 @@ if st.session_state["current_mode"] == "管理":
                     with st.spinner("検索エンジン更新中..."):
                         refresh_search_engine(DEFAULT_KB_NAME)
                     st.toast("検索インデックスを更新しました")
+
+        # Show uploaded items with thumbnail metadata editor
+        display_thumbnail_grid(DEFAULT_KB_NAME)
 
     with tabs[1]:
         kb_name = st.text_input("Knowledge base name", value=DEFAULT_KB_NAME, help="FAQを生成するナレッジベースの名前を入力します。")


### PR DESCRIPTION
## Summary
- show uploaded item thumbnails in the management tab
- test for the call in unified_app
- log new progress

## Testing
- `pip install -r knowledgeplus_design-main/requirements-light.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865f43aa6748333ae45c9dd07680859