### PR TITLE
Improve metadata utilities

### DIFF
--- a/knowledgeplus_design-main/shared/upload_utils.py
+++ b/knowledgeplus_design-main/shared/upload_utils.py
@@ -106,3 +106,34 @@ def save_user_metadata(kb_name: str, item_id: str, title: str, tags: list[str]) 
     with open(meta_path, "w", encoding="utf-8") as f:
         json.dump({"title": title, "tags": tags}, f, ensure_ascii=False, indent=2)
     return str(meta_path)
+
+
+def load_user_metadata(kb_name: str, item_id: str) -> Dict[str, Any]:
+    """Load user-provided metadata for the given item if it exists."""
+    meta_path = BASE_KNOWLEDGE_DIR / kb_name / "metadata" / f"{item_id}_user.json"
+    if meta_path.exists():
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def list_metadata_items(kb_name: str) -> list[tuple[str, Dict[str, Any]]]:
+    """Return (id, metadata) tuples for all items in a knowledge base."""
+    items: list[tuple[str, Dict[str, Any]]] = []
+    meta_dir = BASE_KNOWLEDGE_DIR / kb_name / "metadata"
+    if not meta_dir.exists():
+        return items
+    for meta_path in meta_dir.glob("*.json"):
+        name = meta_path.name
+        if name == "kb_metadata.json" or name.endswith("_user.json"):
+            continue
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except Exception:
+            continue
+        items.append((meta_path.stem, data))
+    return items

--- a/knowledgeplus_design-main/tests/test_upload_utils.py
+++ b/knowledgeplus_design-main/tests/test_upload_utils.py
@@ -54,3 +54,21 @@ def test_save_user_metadata(tmp_path, monkeypatch):
     assert Path(path).exists()
     data = json.loads(Path(path).read_text(encoding="utf-8"))
     assert data == {"title": "Title", "tags": ["x", "y"]}
+
+
+def test_load_user_metadata_and_list(tmp_path, monkeypatch):
+    monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    kb_dir = tmp_path / "kb" / "metadata"
+    kb_dir.mkdir(parents=True)
+    meta_file = kb_dir / "1.json"
+    meta_file.write_text(json.dumps({"paths": {}}), encoding="utf-8")
+    user_file = kb_dir / "1_user.json"
+    user_file.write_text(json.dumps({"title": "T"}), encoding="utf-8")
+
+    items = upload_utils.list_metadata_items("kb")
+    assert items == [("1", {"paths": {}})]
+
+    data = upload_utils.load_user_metadata("kb", "1")
+    assert data == {"title": "T"}
+    missing = upload_utils.load_user_metadata("kb", "nope")
+    assert missing == {}

--- a/knowledgeplus_design-main/ui_modules/thumbnail_editor.py
+++ b/knowledgeplus_design-main/ui_modules/thumbnail_editor.py
@@ -1,10 +1,13 @@
-import json
 from pathlib import Path
 from typing import List, Dict, Any
 
 import streamlit as st
 
-from shared.upload_utils import BASE_KNOWLEDGE_DIR, save_user_metadata
+from shared.upload_utils import (
+    BASE_KNOWLEDGE_DIR,
+    save_user_metadata,
+    list_metadata_items,
+)
 
 
 def _load_items(kb_name: str) -> List[Dict[str, Any]]:
@@ -15,19 +18,7 @@ def _load_items(kb_name: str) -> List[Dict[str, Any]]:
     ``metadata_1``), so the ID may include that prefix.
     """
     items = []
-    meta_dir = BASE_KNOWLEDGE_DIR / kb_name / "metadata"
-    if not meta_dir.exists():
-        return items
-    for meta_path in meta_dir.glob("*.json"):
-        name = meta_path.name
-        if name == "kb_metadata.json" or name.endswith("_user.json"):
-            continue
-        try:
-            with open(meta_path, "r", encoding="utf-8") as f:
-                meta = json.load(f)
-        except Exception:
-            continue
-        item_id = meta_path.stem
+    for item_id, meta in list_metadata_items(kb_name):
         text = ""
         chunk_path = meta.get("paths", {}).get("chunk_path")
         if chunk_path and Path(chunk_path).exists():


### PR DESCRIPTION
## Summary
- centralize metadata helpers in `shared/upload_utils.py`
- use new helpers in `thumbnail_editor`
- test new functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686601437c888333bbae818364dee06d