### PR TITLE
Add OPENAI key check to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ You can similarly override where chat histories are stored by setting
   ./run_app.sh          # macOS/Linux
   run_app.bat           # Windows
   ```
-  The helper scripts check for `OPENAI_API_KEY` and exit if the variable is
-  missing to avoid confusing startup errors.
+  The helper scripts load variables from `.env` if present and then verify that
+  `OPENAI_API_KEY` is set, exiting early if it is missing to avoid confusing
+  startup errors.
 
 If you require model files that are normally fetched from HuggingFace, be aware
 that this environment blocks direct downloads from that service. Retrieve the

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ You can similarly override where chat histories are stored by setting
 * Launch the app with:
 
   ```bash
-  ./run_app.sh
+  ./run_app.sh          # macOS/Linux
+  run_app.bat           # Windows
   ```
+  The helper scripts check for `OPENAI_API_KEY` and exit if the variable is
+  missing to avoid confusing startup errors.
 
 If you require model files that are normally fetched from HuggingFace, be aware
 that this environment blocks direct downloads from that service. Retrieve the

--- a/run_app.bat
+++ b/run_app.bat
@@ -1,4 +1,9 @@
 @echo off
 REM Launch the unified Streamlit interface from repository root
+IF "%OPENAI_API_KEY%"=="" (
+  ECHO OPENAI_API_KEY environment variable not set
+  ECHO Please set it before running the app
+  EXIT /B 1
+)
 cd /d "%~dp0\knowledgeplus_design-main"
 streamlit run app.py

--- a/run_app.bat
+++ b/run_app.bat
@@ -1,8 +1,14 @@
 @echo off
 REM Launch the unified Streamlit interface from repository root
 IF "%OPENAI_API_KEY%"=="" (
+  IF EXIST "%~dp0\.env" (
+    for /f "usebackq tokens=1,* delims==" %%A in ("%~dp0\.env") do set "%%A=%%B"
+  )
+)
+
+IF "%OPENAI_API_KEY%"=="" (
   ECHO OPENAI_API_KEY environment variable not set
-  ECHO Please set it before running the app
+  ECHO Add it to .env or set it before running the app
   EXIT /B 1
 )
 cd /d "%~dp0\knowledgeplus_design-main"

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 # Launch the unified Streamlit interface from repository root
 cd "$(dirname "$0")/knowledgeplus_design-main" || exit 1
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "OPENAI_API_KEY environment variable not set"
+  echo "Please export your key before running the app"
+  exit 1
+fi
+
 streamlit run app.py

--- a/run_app.sh
+++ b/run_app.sh
@@ -2,9 +2,17 @@
 # Launch the unified Streamlit interface from repository root
 cd "$(dirname "$0")/knowledgeplus_design-main" || exit 1
 
+# Load variables from .env if present and OPENAI_API_KEY isn't already set
+if [ -z "$OPENAI_API_KEY" ] && [ -f ../.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ../.env
+  set +a
+fi
+
 if [ -z "$OPENAI_API_KEY" ]; then
   echo "OPENAI_API_KEY environment variable not set"
-  echo "Please export your key before running the app"
+  echo "Add it to .env or export it before running the app"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- stop run_app.sh when OPENAI_API_KEY is missing
- document the new check in README
- add same safeguard to run_app.bat for Windows users

## Testing
- `scripts/install_light.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866324401ac8333b2e3d20715617829