### PR TITLE
Centralize OpenAI client helper

### DIFF
--- a/knowledgeplus_design-main/generate_faq.py
+++ b/knowledgeplus_design-main/generate_faq.py
@@ -1,29 +1,16 @@
 import argparse
 import json
-import os
 from pathlib import Path
 from uuid import uuid4
 import logging
 
 from shared.upload_utils import BASE_KNOWLEDGE_DIR, save_processed_data
+from shared.openai_utils import get_openai_client
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-try:
-    from openai import OpenAI
-except Exception:  # pragma: no cover - openai may not be installed in tests
-    OpenAI = None
 
-
-def get_openai_client():
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key or OpenAI is None:
-        return None
-    try:
-        return OpenAI(api_key=api_key)
-    except Exception:
-        return None
 
 
 def generate_faqs_from_chunks(kb_name: str, max_tokens: int = 1000, num_pairs: int = 3, client=None) -> int:

--- a/knowledgeplus_design-main/knowledge_gpt_app/app.py
+++ b/knowledgeplus_design-main/knowledge_gpt_app/app.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import streamlit as st
-from openai import OpenAI
 from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS, DEFAULT_KB_NAME
 import PyPDF2
 import docx
@@ -54,6 +53,7 @@ from shared.upload_utils import (
     BASE_KNOWLEDGE_DIR as SHARED_KB_DIR,
     ensure_openai_key,
 )
+from shared.openai_utils import get_openai_client
 from generate_faq import generate_faqs_from_chunks
 from ui_modules.theme import apply_intel_theme
 from shared.logging_utils import configure_logging
@@ -120,19 +120,6 @@ except Exception as e:
         f"自作モジュールのインポートに失敗しました: {e}", exc_info=True
     )
 
-# OpenAIクライアントを取得する関数 (app.py内で共通して使用)
-@st.cache_resource
-def get_openai_client():
-    """OpenAIクライアントを取得する関数"""
-    try:
-        api_key = ensure_openai_key()
-        client = OpenAI(api_key=api_key)
-        logger.info("OpenAIクライアントの取得に成功しました。")
-        return client
-    except Exception as e:
-        logger.error(f"OpenAI クライアント初期化エラー: {e}")
-        st.error(f"OpenAI クライアントの初期化中にエラーが発生しました: {e}")
-        return None
 
 # 固定モデル名
 GPT4_MODEL = "gpt-4.1-2025-04-14"

--- a/knowledgeplus_design-main/mm_kb_builder/app.py
+++ b/knowledgeplus_design-main/mm_kb_builder/app.py
@@ -2,14 +2,11 @@ import os
 import sys
 import streamlit as st
 from config import DEFAULT_KB_NAME
-from openai import OpenAI
 import json
 from pathlib import Path
 import logging
 import uuid
-from shared.upload_utils import (
-    ensure_openai_key,
-)
+from shared.openai_utils import get_openai_client
 from shared.file_processor import FileProcessor
 from shared.kb_builder import KnowledgeBuilder
 from ui_modules.theme import apply_intel_theme
@@ -91,16 +88,6 @@ _kb_builder = KnowledgeBuilder(
     get_openai_client_func=get_openai_client,
     refresh_search_engine_func=_refresh_search_engine,
 )
-
-# OpenAIクライアント取得
-@st.cache_resource
-def get_openai_client():
-    try:
-        api_key = ensure_openai_key()
-        return OpenAI(api_key=api_key)
-    except Exception as e:
-        st.error(f"OpenAIクライアント初期化エラー: {e}")
-        return None
 
 def get_embedding(text, client=None):
     """Wrapper for KnowledgeBuilder._get_embedding."""

--- a/knowledgeplus_design-main/shared/openai_utils.py
+++ b/knowledgeplus_design-main/shared/openai_utils.py
@@ -1,0 +1,37 @@
+"""Utility functions for initializing OpenAI clients."""
+
+from typing import Optional
+
+from .upload_utils import ensure_openai_key
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - openai may be missing in tests
+    OpenAI = None
+
+
+def _create_client() -> Optional["OpenAI"]:
+    if OpenAI is None:
+        return None
+    try:
+        api_key = ensure_openai_key()
+    except Exception:
+        return None
+    try:
+        return OpenAI(api_key=api_key)
+    except Exception:
+        return None
+
+
+try:
+    import streamlit as st
+
+    @st.cache_resource  # pragma: no cover - caching only used when Streamlit runs
+    def get_openai_client() -> Optional["OpenAI"]:
+        """Return a cached OpenAI client or ``None`` if initialization fails."""
+        return _create_client()
+except Exception:  # pragma: no cover - Streamlit not available
+
+    def get_openai_client() -> Optional["OpenAI"]:
+        """Return an OpenAI client or ``None`` if initialization fails."""
+        return _create_client()

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -23,11 +23,11 @@ from shared.chat_history_utils import (
 from knowledge_gpt_app.app import (
     list_knowledge_bases,
     semantic_chunking,
-    get_openai_client,
     refresh_search_engine,
-    read_file as app_read_file, # Rename to avoid conflict with FileProcessor
-    search_multiple_knowledge_bases
+    read_file as app_read_file,  # Rename to avoid conflict with FileProcessor
+    search_multiple_knowledge_bases,
 )
+from shared.openai_utils import get_openai_client
 
 # Import FAQ generation (assuming it's a standalone script)
 from generate_faq import generate_faqs_from_chunks


### PR DESCRIPTION
## Summary
- add `shared/openai_utils.py` with a common `get_openai_client()`
- refactor apps and scripts to use this helper
- remove old duplicated implementations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68665d2fd50883338f65a79ec00d125d