### PR TITLE
Remove PyPDF2 stub

### DIFF
--- a/knowledgeplus_design-main/PyPDF2/__init__.py
+++ b/knowledgeplus_design-main/PyPDF2/__init__.py
@@ -1,3 +1,0 @@
-class PdfReader:
-    def __init__(self, *a, **k):
-        self.pages = []


### PR DESCRIPTION
## Summary
- drop the dummy `PyPDF2` package
- confirm PyPDF2>=3.0.1 remains in requirements
- verify PdfReader can extract text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686666f0318c833396211bcdf4d2a07b