### PR TITLE
Use shared openai_utils for OpenAI client creation

### DIFF
--- a/knowledgeplus_design-main/shared/chat_controller.py
+++ b/knowledgeplus_design-main/shared/chat_controller.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from openai import OpenAI
 import logging
 from shared.search_engine import HybridSearchEngine
+from shared.openai_utils import get_openai_client
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -139,11 +140,7 @@ class ChatController:
 
     @staticmethod
     def _get_openai_client_internal(): # Renamed and made static
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if not api_key:
-            logger.warning("OPENAI_API_KEYが環境変数に設定されていません (gpt_handler)")
-            return None
-        return OpenAI(api_key=api_key)
+        return get_openai_client()
 
     def generate_gpt_response(self, user_input, conversation_history=None, persona="default", temperature=None, response_length=None, client=None):
         """

--- a/knowledgeplus_design-main/shared/search_engine.py
+++ b/knowledgeplus_design-main/shared/search_engine.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import re
 import typing
 import logging
+from shared.openai_utils import get_openai_client
 
 logger = logging.getLogger(__name__)
 
@@ -412,15 +413,9 @@ class HybridSearchEngine:
         if model_name is None:
             model_name = self.embedding_model
         if client is None:
-            try:
-                from openai import OpenAI
-                api_key_env = os.getenv("OPENAI_API_KEY")
-                if not api_key_env:
-                    logger.warning("  警告 (get_embedding): OPENAI_API_KEY が未設定。埋め込み取得不可。")
-                    return None
-                client = OpenAI(api_key=api_key_env)
-            except Exception as e_client_init:
-                logger.error(f"  OpenAI Client初期化エラー (get_embedding内): {e_client_init}")
+            client = get_openai_client()
+            if client is None:
+                logger.warning("  警告 (get_embedding): OpenAIクライアントを取得できません。")
                 return None
         if not text or not isinstance(text, str) or len(text.strip()) == 0:
             logger.warning("  警告 (get_embedding): 埋め込み対象のテキストが空または不正。")


### PR DESCRIPTION
## Summary
- rely on `openai_utils.get_openai_client` when the chatbot or search engine create their OpenAI client
- import `get_openai_client` accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686686cdb4b48333918a61db11231c0e