### PR TITLE
Update helper scripts to always load .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ You can similarly override where chat histories are stored by setting
   # or run Streamlit directly from the repository root
   streamlit run app.py
   ```
-  The helper scripts load variables from `.env` if present and then verify that
-  `OPENAI_API_KEY` is set, exiting early if it is missing to avoid confusing
-  startup errors.
+  The helper scripts source `.env` if it exists so optional settings like
+  `KNOWLEDGE_BASE_DIR` are applied. They then verify that `OPENAI_API_KEY` is
+  set, exiting early if the key is missing to avoid confusing startup errors.
 
 When the server starts it will remain active to serve the web UI. This waiting
 state is expected and should not be treated as a failure when Codex prepares a

--- a/run_app.bat
+++ b/run_app.bat
@@ -1,9 +1,7 @@
 @echo off
 REM Launch the unified Streamlit interface from repository root
-IF "%OPENAI_API_KEY%"=="" (
-  IF EXIST "%~dp0\.env" (
-    for /f "usebackq tokens=1,* delims==" %%A in ("%~dp0\.env") do set "%%A=%%B"
-  )
+IF EXIST "%~dp0\.env" (
+  for /f "usebackq tokens=1,* delims==" %%A in ("%~dp0\.env") do set "%%A=%%B"
 )
 
 IF "%OPENAI_API_KEY%"=="" (

--- a/run_app.sh
+++ b/run_app.sh
@@ -2,8 +2,8 @@
 # Launch the unified Streamlit interface from repository root
 cd "$(dirname "$0")/knowledgeplus_design-main" || exit 1
 
-# Load variables from .env if present and OPENAI_API_KEY isn't already set
-if [ -z "$OPENAI_API_KEY" ] && [ -f ../.env ]; then
+# Load variables from .env if present so optional overrides apply
+if [ -f ../.env ]; then
   set -a
   # shellcheck disable=SC1091
   . ../.env


### PR DESCRIPTION
## Summary
- load `.env` unconditionally in helper scripts so optional variables are read
- clarify README description of script behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68669ef9fcec83339cd11591818d4df1