### PR TITLE
Add env override tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ You can similarly override where chat histories are stored by setting
   export CHAT_HISTORY_DIR=/path/to/chat_history
   ```
 
+These variables are evaluated when helper modules such as
+`upload_utils` and `chat_history_utils` are imported. Set them before
+running the application or tests so that all uploads and chat logs are
+stored under the specified directories.
+
 * Launch the app with:
 
   ```bash

--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -53,6 +53,7 @@ streamlit run app.py
 アップロードされたファイルや生成されたデータは `knowledge_base/<kb_name>` 以下に保存されます。デフォルトのナレッジベース名は `config.py` の `DEFAULT_KB_NAME` で定義されています。
 
 保存先ディレクトリを変更したい場合は `KNOWLEDGE_BASE_DIR` 環境変数を、チャット履歴の保存場所を変更したい場合は `CHAT_HISTORY_DIR` を設定してください。
+これらの値は `upload_utils` や `chat_history_utils` などのモジュール読み込み時に適用されます。アプリを起動する前に環境変数を設定しておくと、アップロードされたファイルや会話履歴が指定したディレクトリに保存されます。
 
 ## ✨ 主な機能
 

--- a/knowledgeplus_design-main/tests/test_env_overrides.py
+++ b/knowledgeplus_design-main/tests/test_env_overrides.py
@@ -1,0 +1,29 @@
+import importlib
+from pathlib import Path
+import sys
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+
+
+def test_directory_overrides(tmp_path, monkeypatch):
+    kb_dir = tmp_path / "custom_kb"
+    hist_dir = tmp_path / "custom_hist"
+    monkeypatch.setenv("KNOWLEDGE_BASE_DIR", str(kb_dir))
+    monkeypatch.setenv("CHAT_HISTORY_DIR", str(hist_dir))
+
+    from shared import upload_utils, chat_history_utils
+    importlib.reload(upload_utils)
+    importlib.reload(chat_history_utils)
+
+    assert upload_utils.BASE_KNOWLEDGE_DIR == kb_dir
+    assert chat_history_utils.CHAT_HISTORY_DIR == hist_dir
+
+    upload_utils.save_processed_data("kb", "1", chunk_text="hi", metadata={})
+    hid = chat_history_utils.create_history()
+
+    assert (kb_dir / "kb" / "chunks" / "1.txt").exists()
+    assert (hist_dir / f"{hid}.json").exists()
+
+    monkeypatch.delenv("KNOWLEDGE_BASE_DIR", raising=False)
+    monkeypatch.delenv("CHAT_HISTORY_DIR", raising=False)
+    importlib.reload(upload_utils)
+    importlib.reload(chat_history_utils)


### PR DESCRIPTION
## Summary
- test knowledge base and chat history directory overrides via environment variables
- document that these environment variables are read at import time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68671f7fa8c48333bb2d4470b62e366f