### PR TITLE
Refactor file processor for docx/pdf

### DIFF
--- a/knowledgeplus_design-main/docs/progress.md
+++ b/knowledgeplus_design-main/docs/progress.md
@@ -25,3 +25,8 @@
 ## 2025-07-06
 - Installed dependencies using `scripts/install_light.sh` followed by `scripts/install_extra.sh` to resolve missing modules without network errors.
 - Verified that `pytest -q` completes successfully with 33 tests.
+
+## 2025-07-07
+- Added `extract_text_and_images()` helper in `shared/file_processor.py` to parse DOCX/PDF files and return embedded images.
+- Created `test_file_processor_extract.py` covering DOCX extraction.
+- All tests pass with `pytest -q` (34 tests).

--- a/knowledgeplus_design-main/tests/test_file_processor_extract.py
+++ b/knowledgeplus_design-main/tests/test_file_processor_extract.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import io
+
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+
+import importlib
+from PIL import Image
+import pytest
+
+# Temporarily remove stub path to import real python-docx
+STUBS_DIR = Path(__file__).resolve().parent / "stubs"
+if str(STUBS_DIR) in sys.path:
+    sys.path.remove(str(STUBS_DIR))
+docx = importlib.import_module("docx")
+sys.path.insert(0, str(STUBS_DIR))
+
+from shared.file_processor import FileProcessor
+
+
+def _create_docx_with_image(tmp_path):
+    doc = docx.Document()
+    doc.add_paragraph("hello world")
+    img_path = tmp_path / "img.png"
+    Image.new("RGB", (5, 5), "red").save(img_path)
+    doc.add_picture(str(img_path))
+    out_path = tmp_path / "sample.docx"
+    doc.save(out_path)
+    return out_path
+
+
+def test_extract_text_and_images_docx(tmp_path):
+    doc_path = _create_docx_with_image(tmp_path)
+    with open(doc_path, "rb") as f:
+        text, images = FileProcessor.extract_text_and_images(f)
+    assert "hello world" in text
+    assert len(images) == 1


### PR DESCRIPTION
## Summary
- add `extract_text_and_images` helper to handle DOCX and PDF parsing
- test DOCX extraction logic
- document new helper in progress log

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686735cac4908333838c34de7c7b3b44