### PR TITLE
Refactor sidebar toggle

### DIFF
--- a/knowledgeplus_design-main/tests/test_sidebar_toggle.py
+++ b/knowledgeplus_design-main/tests/test_sidebar_toggle.py
@@ -21,3 +21,15 @@ def test_sidebar_toggle_updates_state(monkeypatch):
     sidebar_toggle.render_sidebar_toggle(key="test_toggle")
     assert st.session_state.get('sidebar_visible') is True
     assert calls['rerun'] is True
+
+
+def test_sidebar_toggle_custom_width(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(st, 'button', lambda *a, **k: False)
+    monkeypatch.setattr(st, 'rerun', lambda: None)
+    monkeypatch.setattr(st, 'markdown', lambda text, **k: captured.setdefault('css', text))
+    sidebar_toggle = importlib.import_module('ui_modules.sidebar_toggle')
+
+    st.session_state.clear()
+    sidebar_toggle.render_sidebar_toggle(key="toggle_w", sidebar_width="25rem")
+    assert '25rem' in captured.get('css', '')

--- a/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
+++ b/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
@@ -5,8 +5,21 @@ def render_sidebar_toggle(
     key: str = "toggle_sidebar",
     collapsed_label: str = "＞＞",
     expanded_label: str = "＜＜",
+    sidebar_width: str = "18rem",
 ) -> None:
-    """Display a toggle button to collapse or expand the sidebar."""
+    """Display a toggle button to collapse or expand the sidebar.
+
+    Parameters
+    ----------
+    key: str
+        Session state key for the toggle button.
+    collapsed_label: str
+        Label shown when the sidebar is hidden.
+    expanded_label: str
+        Label shown when the sidebar is visible.
+    sidebar_width: str
+        CSS width of the sidebar; allow overrides for custom layouts.
+    """
     if "sidebar_visible" not in st.session_state:
         st.session_state["sidebar_visible"] = False
 
@@ -15,12 +28,14 @@ def render_sidebar_toggle(
         st.session_state.sidebar_visible = not st.session_state.sidebar_visible
         st.rerun()
 
+    margin = "0" if st.session_state.sidebar_visible else f"-{sidebar_width}"
     st.markdown(
         f"""
         <style>
         [data-testid='stSidebar'] {{
             transition: margin-left 0.3s ease;
-            margin-left: {'0' if st.session_state.sidebar_visible else '-18rem'};
+            margin-left: {margin};
+            width: {sidebar_width};
         }}
         </style>
         """,


### PR DESCRIPTION
## Summary
- make sidebar toggle width configurable
- cover new width option in tests

## Testing
- `pytest knowledgeplus_design-main/tests/test_sidebar_toggle.py::test_sidebar_toggle_updates_state -q`
- `pytest knowledgeplus_design-main/tests/test_sidebar_toggle.py::test_sidebar_toggle_custom_width -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686739e38c9883339d5e2fb10dc2cc21