### PR TITLE
Show chat title

### DIFF
--- a/knowledgeplus_design-main/ui_modules/chat_ui.py
+++ b/knowledgeplus_design-main/ui_modules/chat_ui.py
@@ -12,6 +12,10 @@ from config import DEFAULT_KB_NAME
 def render_chat_mode(safe_generate_gpt_response):
     """Render the chat interface."""
     st.subheader("チャット")
+    # Display current conversation title underneath the header
+    st.markdown(
+        f"### {st.session_state.get('gpt_conversation_title', '新しい会話')}"
+    )
     use_kb = st.checkbox(
         "全てのナレッジから検索する",
         value=st.session_state.get("use_knowledge_search", True),


### PR DESCRIPTION
## Summary
- display the current conversation title at the top of the chat view

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673c569cd083339ed03e2632f3ce58