### PR TITLE
Implement metadata extraction helper

### DIFF
--- a/knowledgeplus_design-main/shared/file_processor.py
+++ b/knowledgeplus_design-main/shared/file_processor.py
@@ -310,6 +310,24 @@ class FileProcessor:
             logger.error(f"Document extraction error: {e}")
         return text, images
 
+    @staticmethod
+    def create_metadata_from_text(text: str, images: list[str]) -> dict:
+        """Return minimal metadata using the given text and images.
+
+        This helper generates a short summary from the beginning of the text and
+        records the number of extracted images.  It avoids heavy model calls so
+        that PDF/DOCX processing remains lightweight.
+        """
+        summary = text.replace("\n", " ")[:100]
+        return {"summary": summary, "image_count": len(images)}
+
+    @staticmethod
+    def extract_text_images_metadata(file_obj):
+        """Return text, images and simple metadata for DOCX or PDF files."""
+        text, images = FileProcessor.extract_text_and_images(file_obj)
+        meta = FileProcessor.create_metadata_from_text(text, images)
+        return text, images, meta
+
     @classmethod
     def process_file(cls, file):
         file_extension = Path(file.name).suffix.lower().replace('.', '')

--- a/knowledgeplus_design-main/tests/test_file_processor_metadata.py
+++ b/knowledgeplus_design-main/tests/test_file_processor_metadata.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+
+from PIL import Image
+import importlib
+
+# Remove stubs to load real python-docx
+STUBS_DIR = Path(__file__).resolve().parent / "stubs"
+if str(STUBS_DIR) in sys.path:
+    sys.path.remove(str(STUBS_DIR))
+docx = importlib.import_module("docx")
+sys.path.insert(0, str(STUBS_DIR))
+
+from shared.file_processor import FileProcessor
+
+
+def _create_docx_with_image(tmp_path):
+    doc = docx.Document()
+    doc.add_paragraph("hello world")
+    img_path = tmp_path / "img.png"
+    Image.new("RGB", (5, 5), "red").save(img_path)
+    doc.add_picture(str(img_path))
+    out_path = tmp_path / "sample.docx"
+    doc.save(out_path)
+    return out_path
+
+
+def test_extract_text_images_metadata(tmp_path):
+    doc_path = _create_docx_with_image(tmp_path)
+    with open(doc_path, "rb") as f:
+        text, images, meta = FileProcessor.extract_text_images_metadata(f)
+    assert "hello world" in text
+    assert len(images) == 1
+    assert meta["image_count"] == 1
+    assert meta["summary"].startswith("hello world")


### PR DESCRIPTION
## Summary
- expand FileProcessor with simple metadata generation
- expose new extract_text_images_metadata helper
- cover new function with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867413767b0833399eb498920b9a7ac