### PR TITLE
Add pre-commit config and usage docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        args: [--safe]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.1.14
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ If you require model files that are normally fetched from HuggingFace, be aware
 that this environment blocks direct downloads from that service. Retrieve the
 same files from a mirror or copy them locally before launching the app.
 
+## Pre-commit
+
+Set up git hooks so code style checks run automatically:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
 ## Testing
 
 Before running `pytest`, install the test dependencies:


### PR DESCRIPTION
## Summary
- set up `.pre-commit-config.yaml` with black, ruff and isort
- document installing and enabling pre-commit hooks

## Testing
- `pre-commit run --files README.md .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686753a153b083338f84fe2a1634eecb