### PR TITLE
Add tests for mm_builder_utils image analysis

### DIFF
--- a/knowledgeplus_design-main/tests/test_mm_builder_utils.py
+++ b/knowledgeplus_design-main/tests/test_mm_builder_utils.py
@@ -1,0 +1,30 @@
+import types
+from pathlib import Path
+import sys
+
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+
+from core import mm_builder_utils
+
+
+def test_analyze_image_with_gpt4o_parses_json(monkeypatch):
+    # Prepare fake OpenAI client returning JSON text
+    def fake_create(**kwargs):
+        return types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='{"foo": "bar"}'))]
+        )
+
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create))
+    )
+
+    monkeypatch.setattr(mm_builder_utils, "get_openai_client", lambda: client)
+
+    result = mm_builder_utils.analyze_image_with_gpt4o("imgdata", "img.png")
+    assert result == {"foo": "bar"}
+
+
+def test_analyze_image_with_gpt4o_missing_client(monkeypatch):
+    monkeypatch.setattr(mm_builder_utils, "get_openai_client", lambda: None)
+    result = mm_builder_utils.analyze_image_with_gpt4o("b64", "file.png")
+    assert result == {"error": "OpenAIクライアントが利用できません"}


### PR DESCRIPTION
## Summary
- add unit tests for `analyze_image_with_gpt4o` in `core.mm_builder_utils`
- ensure JSON is parsed correctly and missing client errors are handled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867561d3b3c8333bf34d8ede63e2dea