### PR TITLE
Add docx/xlsx support

### DIFF
--- a/knowledgeplus_design-main/mm_kb_builder/app.py
+++ b/knowledgeplus_design-main/mm_kb_builder/app.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 GPT4O_MODEL = "gpt-4.1"
 
 SUPPORTED_IMAGE_TYPES = ['jpg', 'jpeg', 'png', 'bmp', 'tiff', 'webp']
-SUPPORTED_DOCUMENT_TYPES = ['pdf']
+SUPPORTED_DOCUMENT_TYPES = ['pdf', 'docx', 'doc', 'xlsx', 'xls', 'txt']
 SUPPORTED_CAD_TYPES = ['dxf', 'stl', 'ply', 'obj', 'step', 'stp', 'iges', 'igs', '3ds']
 
 # 共通ナレッジベースディレクトリ

--- a/knowledgeplus_design-main/shared/file_processor.py
+++ b/knowledgeplus_design-main/shared/file_processor.py
@@ -58,7 +58,9 @@ logger = logging.getLogger(__name__)
 
 class FileProcessor:
     SUPPORTED_IMAGE_TYPES = ['jpg', 'jpeg', 'png', 'bmp', 'tiff', 'webp']
-    SUPPORTED_DOCUMENT_TYPES = ['pdf']
+    SUPPORTED_DOCUMENT_TYPES = [
+        'pdf', 'docx', 'doc', 'xlsx', 'xls', 'txt'
+    ]
     SUPPORTED_CAD_TYPES = ['dxf', 'stl', 'ply', 'obj', 'step', 'stp', 'iges', 'igs', '3ds']
 
     @staticmethod

--- a/knowledgeplus_design-main/tests/stubs/numpy/__init__.py
+++ b/knowledgeplus_design-main/tests/stubs/numpy/__init__.py
@@ -9,6 +9,10 @@ datetime64 = int
 timedelta64 = int
 int64 = int
 float64 = float
+integer = int
+
+class busdaycalendar:
+    pass
 
 float32 = float
 
@@ -29,6 +33,11 @@ def dot(a, b):
     return sum(float(x) * float(y) for x, y in zip(a, b))
 
 
+class dtype:
+    def __init__(self, t):
+        self.type = t
+
+
 class _Linalg:
     @staticmethod
     def norm(vec):
@@ -39,7 +48,23 @@ linalg = _Linalg()
 # Provide minimal submodules so ``import numpy.random`` and
 # ``import numpy.core`` succeed in tests without installing the real
 # NumPy package.
-random = SimpleNamespace()
+class _Generator:  # minimal stub for pandas
+    pass
+
+
+class _BitGenerator:  # minimal stub for pandas
+    pass
+
+
+class _RandomState:
+    pass
+
+
+random = SimpleNamespace(
+    Generator=_Generator,
+    BitGenerator=_BitGenerator,
+    RandomState=_RandomState,
+)
 core = SimpleNamespace()
 sys.modules.setdefault(__name__ + ".random", random)
 sys.modules.setdefault(__name__ + ".core", core)

--- a/knowledgeplus_design-main/tests/test_supported_docs.py
+++ b/knowledgeplus_design-main/tests/test_supported_docs.py
@@ -1,0 +1,23 @@
+from shared.file_processor import FileProcessor
+from pathlib import Path
+import ast
+
+KB_APP_PATH = Path(__file__).resolve().parents[1] / 'mm_kb_builder' / 'app.py'
+source = KB_APP_PATH.read_text(encoding='utf-8')
+module = ast.parse(source)
+SUPPORTED_DOCS = None
+for node in module.body:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == 'SUPPORTED_DOCUMENT_TYPES':
+                SUPPORTED_DOCS = [elt.s for elt in node.value.elts]
+                break
+    if SUPPORTED_DOCS:
+        break
+
+def test_supported_document_types():
+    assert 'docx' in FileProcessor.SUPPORTED_DOCUMENT_TYPES
+    assert 'xlsx' in FileProcessor.SUPPORTED_DOCUMENT_TYPES
+    assert SUPPORTED_DOCS is not None
+    assert 'docx' in SUPPORTED_DOCS
+    assert 'xlsx' in SUPPORTED_DOCS


### PR DESCRIPTION
## Summary
- support docx/xlsx/txt in `FileProcessor.SUPPORTED_DOCUMENT_TYPES`
- expose same extensions in mm_kb_builder app
- update numpy stub to satisfy pandas during tests
- adjust tests to load real app modules without heavy deps
- new test ensuring docx and xlsx are allowed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675b198b0883338ba4072d81bd4a3a