### PR TITLE
Fix Windows script line endings

### DIFF
--- a/knowledgeplus_design-main/run_app.bat
+++ b/knowledgeplus_design-main/run_app.bat
@@ -1,5 +1,16 @@
 @echo off
 REM Launch the unified Streamlit interface
 cd /d "%~dp0"
+
+IF EXIST "..\.env" (
+  for /f "usebackq tokens=1,* delims==" %%A in ("..\.env") do set "%%A=%%B"
+)
+
+IF "%OPENAI_API_KEY%"=="" (
+  ECHO OPENAI_API_KEY environment variable not set
+  ECHO Add it to ..\.env or set it before running the app
+  EXIT /B 1
+)
+
 streamlit run app.py
 

--- a/knowledgeplus_design-main/run_app.sh
+++ b/knowledgeplus_design-main/run_app.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 # Launch the unified Streamlit interface
 cd "$(dirname "$0")" || exit 1
+
+# Load variables from ../.env if present so optional overrides apply
+if [ -f ../.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ../.env
+  set +a
+fi
+
+if [ -z "$OPENAI_API_KEY" ]; then
+  echo "OPENAI_API_KEY environment variable not set"
+  echo "Add it to ../.env or export it before running the app"
+  exit 1
+fi
+
 streamlit run app.py
 


### PR DESCRIPTION
## Summary
- ensure `run_app.bat` uses CRLF line endings so Windows can run it
- retain env var loading in `run_app.sh` and `.bat`

## Testing
- `bash scripts/install_light.sh`
- `pytest -q`
- `pre-commit run --files knowledgeplus_design-main/run_app.sh knowledgeplus_design-main/run_app.bat`


------
https://chatgpt.com/codex/tasks/task_e_68677409cd148333b2fdbf3a90853f20