### PR TITLE
Add history loader

### DIFF
--- a/knowledgeplus_design-main/shared/chat_history_utils.py
+++ b/knowledgeplus_design-main/shared/chat_history_utils.py
@@ -44,6 +44,18 @@ def load_chat_histories() -> List[Dict]:
     return histories
 
 
+def load_history(history_id: str) -> Optional[Dict]:
+    """Return a single chat history dict or ``None`` if unavailable."""
+    path = get_history_path(history_id)
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
 def create_history(settings: Optional[Dict] = None) -> str:
     """Create a new chat history file and return its ID."""
     history_id = str(uuid.uuid4())

--- a/knowledgeplus_design-main/tests/test_chat_history_utils.py
+++ b/knowledgeplus_design-main/tests/test_chat_history_utils.py
@@ -27,3 +27,16 @@ def test_chat_history_lifecycle(tmp_path, monkeypatch):
 
     assert chu.delete_history(hid) is True
     assert not (tmp_path / f"{hid}.json").exists()
+
+
+def test_load_history(tmp_path, monkeypatch):
+    monkeypatch.setattr(chu, "CHAT_HISTORY_DIR", tmp_path)
+    tmp_path.mkdir(exist_ok=True)
+    hid = chu.create_history()
+    chu.append_message(hid, "user", "hi")
+
+    data = chu.load_history(hid)
+    assert data is not None
+    assert data["messages"][0]["content"] == "hi"
+
+    assert chu.load_history("missing") is None


### PR DESCRIPTION
## Summary
- implement `load_history` for single file access
- test loading individual histories

## Testing
- `scripts/install_light.sh`
- `scripts/install_extra.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68677a04aca4833392573e0674bbffad