### PR TITLE
Enable env override for default KB

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ You can similarly override where chat histories are stored by setting
   export CHAT_HISTORY_DIR=/path/to/chat_history
   ```
 
+You can override the default knowledge base name by setting
+`DEFAULT_KB_NAME` before running the app:
+
+  ```bash
+  export DEFAULT_KB_NAME=my_kb
+  ```
+
 These variables are evaluated when helper modules such as
 `upload_utils` and `chat_history_utils` are imported. Set them before
 running the application or tests so that all uploads and chat logs are

--- a/knowledgeplus_design-main/.env.example
+++ b/knowledgeplus_design-main/.env.example
@@ -2,3 +2,4 @@ OPENAI_API_KEY=your_api_key_here
 
 KNOWLEDGE_BASE_DIR=knowledge_base
 CHAT_HISTORY_DIR=chat_history
+DEFAULT_KB_NAME=default_kb

--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -50,7 +50,7 @@ PDFエクスポートには日本語フォント `ipaexg.ttf` が必要です。
 streamlit run app.py
 ```
 
-アップロードされたファイルや生成されたデータは `knowledge_base/<kb_name>` 以下に保存されます。デフォルトのナレッジベース名は `config.py` の `DEFAULT_KB_NAME` で定義されています。
+アップロードされたファイルや生成されたデータは `knowledge_base/<kb_name>` 以下に保存されます。デフォルトのナレッジベース名は `config.py` の `DEFAULT_KB_NAME` で定義されており、環境変数 `DEFAULT_KB_NAME` で上書きできます。
 
 保存先ディレクトリを変更したい場合は `KNOWLEDGE_BASE_DIR` 環境変数を、チャット履歴の保存場所を変更したい場合は `CHAT_HISTORY_DIR` を設定してください。
 これらの値は `upload_utils` や `chat_history_utils` などのモジュール読み込み時に適用されます。アプリを起動する前に環境変数を設定しておくと、アップロードされたファイルや会話履歴が指定したディレクトリに保存されます。

--- a/knowledgeplus_design-main/config.py
+++ b/knowledgeplus_design-main/config.py
@@ -1,6 +1,8 @@
+import os
+
 EMBEDDING_MODEL = "text-embedding-3-large"
 EMBEDDING_DIMENSIONS = 3072
 
-# Default location for saved chunks, embeddings and other assets
-# from both the chatbot and the multimodal builder.
-DEFAULT_KB_NAME = "default_kb"
+# Default knowledge base name can be overridden via the environment
+# to simplify customization in different deployments.
+DEFAULT_KB_NAME = os.getenv("DEFAULT_KB_NAME", "default_kb")


### PR DESCRIPTION
## Summary
- allow overriding `DEFAULT_KB_NAME` via environment variable
- document `DEFAULT_KB_NAME` usage in READMEs
- update `.env.example`

## Testing
- `scripts/install_light.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686780737cd08333a147acec69a70d58