### PR TITLE
Add Codex guidelines and history utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ scripts/install_extra.sh  # add the heavy packages later
 When using Codex for automated contributions, run the light script first and
 install the extras separately. This avoids network errors that can lead to pull
 request failures.
+
+## Codex tips
+
+Automated commits must keep the repository clean to prevent pull request
+failures. Run `pytest -q` before submitting changes and install dependencies in
+two stages so heavy packages download separately. When running `run_app.sh` the
+process stays active waiting for connections—this is normal and should not be
+treated as an error.
 * Copy `knowledgeplus_design-main/.env.example` to `.env` and set the OpenAI key before starting:
 
   ```bash

--- a/knowledgeplus_design-main/knowledge_gpt_app/app.py
+++ b/knowledgeplus_design-main/knowledge_gpt_app/app.py
@@ -21,6 +21,7 @@ import shutil
 from datetime import datetime
 import uuid
 from pathlib import Path
+from typing import Any, Dict, List
 import logging
 from nltk.tokenize import word_tokenize
 import time
@@ -527,8 +528,9 @@ def refresh_search_engine(kb_name: str) -> None:
         except Exception as e:
             logger.error(f"Failed to refresh index for '{kb_name}': {e}", exc_info=True)
 
-def list_knowledge_bases():
-    kb_list = []
+def list_knowledge_bases() -> List[Dict[str, Any]]:
+    """Return metadata dictionaries for all available knowledge bases."""
+    kb_list: List[Dict[str, Any]] = []
     if RAG_BASE_DIR.exists():
         for kb_dir_path in RAG_BASE_DIR.iterdir():
             if kb_dir_path.is_dir():

--- a/knowledgeplus_design-main/shared/chat_history_utils.py
+++ b/knowledgeplus_design-main/shared/chat_history_utils.py
@@ -44,6 +44,11 @@ def load_chat_histories() -> List[Dict]:
     return histories
 
 
+def list_history_ids() -> List[str]:
+    """Return history file IDs sorted by creation time."""
+    return [h["id"] for h in load_chat_histories()]
+
+
 def load_history(history_id: str) -> Optional[Dict]:
     """Return a single chat history dict or ``None`` if unavailable."""
     path = get_history_path(history_id)


### PR DESCRIPTION
## Summary
- document tips for using Codex safely
- expose `list_history_ids` helper for chat history
- annotate `list_knowledge_bases()` return value

## Testing
- `pre-commit run --files README.md knowledgeplus_design-main/shared/chat_history_utils.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867ce548dd88333af8928eef18b256a