### PR TITLE
Add sidebar visibility option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ You can similarly override where chat histories are stored by setting
   export CHAT_HISTORY_DIR=/path/to/chat_history
   ```
 
+The sidebar defaults to collapsed.  Set `SIDEBAR_DEFAULT_VISIBLE=true` before
+launching to keep it expanded when the app starts:
+
+  ```bash
+  export SIDEBAR_DEFAULT_VISIBLE=true
+  ```
+
 You can override the default knowledge base name by setting
 `DEFAULT_KB_NAME` before running the app:
 

--- a/knowledgeplus_design-main/tests/test_sidebar_toggle.py
+++ b/knowledgeplus_design-main/tests/test_sidebar_toggle.py
@@ -33,3 +33,19 @@ def test_sidebar_toggle_custom_width(monkeypatch):
     st.session_state.clear()
     sidebar_toggle.render_sidebar_toggle(key="toggle_w", sidebar_width="25rem")
     assert '25rem' in captured.get('css', '')
+
+
+def test_sidebar_toggle_initial_state_from_env(monkeypatch):
+    monkeypatch.setattr(st, 'button', lambda *a, **k: False)
+    monkeypatch.setattr(st, 'markdown', lambda *a, **k: None)
+    monkeypatch.setattr(st, 'rerun', lambda: None)
+    monkeypatch.setenv('SIDEBAR_DEFAULT_VISIBLE', 'true')
+
+    # Reload module so the environment variable is read
+    if 'ui_modules.sidebar_toggle' in sys.modules:
+        del sys.modules['ui_modules.sidebar_toggle']
+    sidebar_toggle = importlib.import_module('ui_modules.sidebar_toggle')
+
+    st.session_state.clear()
+    sidebar_toggle.render_sidebar_toggle(key='toggle_env')
+    assert st.session_state.get('sidebar_visible') is True

--- a/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
+++ b/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
@@ -3,6 +3,10 @@ import streamlit as st
 
 
 DEFAULT_SIDEBAR_WIDTH = os.getenv("SIDEBAR_WIDTH", "18rem")
+# Allow the initial visibility to be configured so different deployments
+# can start with the sidebar expanded or collapsed. The value is treated
+# as a boolean where "1", "true" or "yes" enable the sidebar.
+DEFAULT_SIDEBAR_VISIBLE = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "false").lower() in {"1", "true", "yes"}
 
 
 def render_sidebar_toggle(
@@ -26,7 +30,7 @@ def render_sidebar_toggle(
         the ``SIDEBAR_WIDTH`` environment variable to customize layouts.
     """
     if "sidebar_visible" not in st.session_state:
-        st.session_state["sidebar_visible"] = False
+        st.session_state["sidebar_visible"] = DEFAULT_SIDEBAR_VISIBLE
 
     toggle_label = collapsed_label if not st.session_state.sidebar_visible else expanded_label
     if st.button(toggle_label, key=key, help="サイドバーの表示切替"):


### PR DESCRIPTION
## Summary
- configure sidebar default visibility via `SIDEBAR_DEFAULT_VISIBLE`
- document the new environment variable
- test sidebar toggle env handling

## Testing
- `scripts/install_light.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867d8cf0ff08333b130f520651cd447