### PR TITLE
Update env loader and tests

### DIFF
--- a/knowledgeplus_design-main/shared/env.py
+++ b/knowledgeplus_design-main/shared/env.py
@@ -1,20 +1,32 @@
-from __future__ import annotations
-
 """Environment utilities for loading configuration."""
 
+from __future__ import annotations
+
 from pathlib import Path
+
 from dotenv import load_dotenv
 
 _env_loaded = False
 
 
-def load_env(path: str | Path | None = None) -> None:
-    """Load environment variables from a .env file once."""
+def load_env(path: str | Path | None = None, *, force: bool = False) -> None:
+    """Load environment variables from a .env file.
+
+    Parameters
+    ----------
+    path
+        Optional path to the ``.env`` file.  Defaults to ``.env`` in the
+        repository root.
+    force
+        Reload even if variables were previously loaded.
+    """
+
     global _env_loaded
-    if _env_loaded:
+    if _env_loaded and not force:
         return
 
     env_path = Path(path) if path else Path(__file__).resolve().parents[2] / ".env"
+    loaded = False
     if env_path.exists():
-        load_dotenv(env_path)
-    _env_loaded = True
+        loaded = bool(load_dotenv(env_path))
+    _env_loaded = loaded

--- a/knowledgeplus_design-main/tests/test_env.py
+++ b/knowledgeplus_design-main/tests/test_env.py
@@ -1,6 +1,6 @@
+import importlib
 import os
 import sys
-import importlib
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -12,6 +12,26 @@ def test_load_env_reads_values(tmp_path, monkeypatch):
     env_file.write_text("FOO=bar\n", encoding="utf-8")
     monkeypatch.delenv("FOO", raising=False)
     import shared.env as env
+
     importlib.reload(env)
     env.load_env(env_file)
     assert os.getenv("FOO") == "bar"
+
+
+def test_load_env_then_reload(tmp_path, monkeypatch):
+    """Calling load_env twice should load variables only when a file exists."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("BAR=baz\n", encoding="utf-8")
+
+    monkeypatch.delenv("BAR", raising=False)
+    import shared.env as env
+
+    importlib.reload(env)
+
+    # First call without a file present does nothing
+    env.load_env(Path("nonexistent"))
+    assert os.getenv("BAR") is None
+
+    # Second call with a valid file should load the variable
+    env.load_env(env_file)
+    assert os.getenv("BAR") == "baz"


### PR DESCRIPTION
## Summary
- adjust environment loader so `_env_loaded` is set only when a file is loaded
- allow reloading by adding a `force` parameter
- test reloading behaviour in `load_env`

## Testing
- `pre-commit run --files knowledgeplus_design-main/shared/env.py knowledgeplus_design-main/tests/test_env.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867eb1bd0bc83338bffeabbd5c186d1