### PR TITLE
Add OpenAI patch test

### DIFF
--- a/knowledgeplus_design-main/tests/test_prompt_advisor.py
+++ b/knowledgeplus_design-main/tests/test_prompt_advisor.py
@@ -22,3 +22,29 @@ def test_generate_prompt_advice_returns_text():
     client = MockClient("- improved")
     result = generate_prompt_advice("hello", client=client)
     assert result == "- improved"
+
+
+def test_generate_prompt_advice_uses_openai(monkeypatch):
+    """generate_prompt_advice should call OpenAI when no client is supplied."""
+    import openai
+    from shared import prompt_advisor
+
+    advice = "use more detail"
+
+    class DummyOpenAI:
+        def __init__(self, api_key=None):
+            self.chat = types.SimpleNamespace(
+                completions=types.SimpleNamespace(
+                    create=lambda **_: types.SimpleNamespace(
+                        choices=[types.SimpleNamespace(
+                            message=types.SimpleNamespace(content=advice)
+                        )]
+                    )
+                )
+            )
+
+    monkeypatch.setattr(prompt_advisor, "OpenAI", DummyOpenAI)
+    monkeypatch.setattr(prompt_advisor, "ensure_openai_key", lambda: "key")
+
+    result = prompt_advisor.generate_prompt_advice("prompt")
+    assert isinstance(result, str) and result


### PR DESCRIPTION
## Summary
- expand prompt advisor tests
- ensure OpenAI initialization and API key path are covered

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867fa1996a08333b69487f8a80a606b