### PR TITLE
Add test for missing kb metadata warning

### DIFF
--- a/knowledgeplus_design-main/shared/search_engine.py
+++ b/knowledgeplus_design-main/shared/search_engine.py
@@ -335,7 +335,9 @@ class HybridSearchEngine:
             except Exception as e:
                 logger.error(f"ナレッジベースメタデータ読み込みエラー: {e}", exc_info=True)
         else:
-            logger.info(f"ナレッジベースメタデータファイルが見つかりません: {metadata_file}")
+            logger.warning(
+                f"ナレッジベースメタデータファイルが見つかりません: {metadata_file}"
+            )
         return {}
 
     def _load_chunks(self) -> list[dict]:

--- a/knowledgeplus_design-main/tests/test_search_engine.py
+++ b/knowledgeplus_design-main/tests/test_search_engine.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import json
 from unittest.mock import MagicMock, patch
 import numpy as np
+import logging
 
 # Adjust the import path to allow importing from shared
 import sys
@@ -167,3 +168,17 @@ def test_bm25_tokenization_internal():
 
     tokens_empty_after_processing_jp = tokenize_text_for_bm25_internal("の に は")
     assert tokens_empty_after_processing_jp == ["<bm25_all_stopwords_token>"]
+
+
+def test_missing_kb_metadata_logs_warning(tmp_path, caplog):
+    kb_dir = tmp_path / "kb_no_meta"
+    (kb_dir / "chunks").mkdir(parents=True)
+    (kb_dir / "metadata").mkdir()
+    (kb_dir / "embeddings").mkdir()
+
+    with caplog.at_level(logging.WARNING):
+        HybridSearchEngine(str(kb_dir))
+
+    assert any(
+        "メタデータファイルが見つかりません" in r.message for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log a warning when kb_metadata.json is absent
- test HybridSearchEngine warning for missing metadata

## Testing
- `bash scripts/install_light.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686e64b5508333a456a7afbc780110