### PR TITLE
Refine UI header and sidebar

### DIFF
--- a/knowledgeplus_design-main/ui_modules/chat_ui.py
+++ b/knowledgeplus_design-main/ui_modules/chat_ui.py
@@ -1,28 +1,26 @@
 import streamlit as st
-from shared.openai_utils import get_openai_client
-from shared.chat_controller import ChatController
-from shared.search_engine import HybridSearchEngine
-from knowledge_gpt_app.app import search_multiple_knowledge_bases
-from shared.upload_utils import BASE_KNOWLEDGE_DIR
-from shared.chat_history_utils import append_message, update_title
-from shared.prompt_advisor import generate_prompt_advice
 from config import DEFAULT_KB_NAME
+from knowledge_gpt_app.app import search_multiple_knowledge_bases
+from shared.chat_controller import ChatController
+from shared.chat_history_utils import append_message, update_title
+from shared.openai_utils import get_openai_client
+from shared.prompt_advisor import generate_prompt_advice
+from shared.search_engine import HybridSearchEngine
+from shared.upload_utils import BASE_KNOWLEDGE_DIR
 
 
 def render_chat_mode(safe_generate_gpt_response):
     """Render the chat interface."""
     st.subheader("チャット")
     # Display current conversation title underneath the header
-    st.markdown(
-        f"### {st.session_state.get('gpt_conversation_title', '新しい会話')}"
-    )
+    st.markdown(f"### {st.session_state.get('gpt_conversation_title', '新しい会話')}")
     use_kb = st.checkbox(
         "全てのナレッジから検索する",
         value=st.session_state.get("use_knowledge_search", True),
     )
     st.session_state["use_knowledge_search"] = use_kb
 
-    chat_container = st.container(height=None)
+    chat_container = st.container(height=600)
     with chat_container:
         for msg in st.session_state["chat_history"]:
             with st.chat_message(msg["role"]):
@@ -39,21 +37,31 @@ def render_chat_mode(safe_generate_gpt_response):
                 advice_text = generate_prompt_advice(user_msg, client=client)
                 if advice_text:
                     st.info(f"💡 プロンプトアドバイス:\n{advice_text}")
-                    st.session_state["chat_history"].append({"role": "info", "content": advice_text})
-                    append_message(st.session_state.current_chat_id, "info", advice_text)
+                    st.session_state["chat_history"].append(
+                        {"role": "info", "content": advice_text}
+                    )
+                    append_message(
+                        st.session_state.current_chat_id, "info", advice_text
+                    )
 
         context = ""
         if use_kb:
-            if "chat_controller" not in st.session_state or not isinstance(st.session_state.chat_controller, ChatController):
+            if "chat_controller" not in st.session_state or not isinstance(
+                st.session_state.chat_controller, ChatController
+            ):
                 try:
-                    engine = HybridSearchEngine(str(BASE_KNOWLEDGE_DIR / DEFAULT_KB_NAME))
+                    engine = HybridSearchEngine(
+                        str(BASE_KNOWLEDGE_DIR / DEFAULT_KB_NAME)
+                    )
                     st.session_state.chat_controller = ChatController(engine)
                 except Exception as e:
                     st.error(f"ナレッジベースの初期化に失敗しました: {e}")
                     st.session_state.chat_controller = None
 
             if st.session_state.chat_controller:
-                results, _ = search_multiple_knowledge_bases(user_msg, [DEFAULT_KB_NAME])
+                results, _ = search_multiple_knowledge_bases(
+                    user_msg, [DEFAULT_KB_NAME]
+                )
                 context = "\n".join(r.get("text", "") for r in results[:3])
                 if not context:
                     st.info("ナレッジ検索で関連情報が見つかりませんでした。AIの一般的な知識で回答します。")
@@ -67,7 +75,9 @@ def render_chat_mode(safe_generate_gpt_response):
                 if use_kb and context
                 else user_msg
             )
-            chat_temp = 0.2 if use_kb else float(st.session_state.get("temperature", 0.7))
+            chat_temp = (
+                0.2 if use_kb else float(st.session_state.get("temperature", 0.7))
+            )
             chat_persona = st.session_state.get("persona", "default")
 
             with st.chat_message("assistant"):
@@ -93,7 +103,9 @@ def render_chat_mode(safe_generate_gpt_response):
             answer = full_response
         else:
             answer = "OpenAIクライアントを初期化できませんでした。"
-        st.session_state["chat_history"].append({"role": "assistant", "content": answer})
+        st.session_state["chat_history"].append(
+            {"role": "assistant", "content": answer}
+        )
         append_message(st.session_state.current_chat_id, "assistant", answer)
 
         if (
@@ -102,11 +114,16 @@ def render_chat_mode(safe_generate_gpt_response):
             and client
         ):
             current_history_for_title_gen = [
-                m for m in st.session_state.chat_history if m["role"] in ["user", "assistant"]
+                m
+                for m in st.session_state.chat_history
+                if m["role"] in ["user", "assistant"]
             ]
             if current_history_for_title_gen:
                 try:
-                    if "chat_controller" in st.session_state and st.session_state.chat_controller:
+                    if (
+                        "chat_controller" in st.session_state
+                        and st.session_state.chat_controller
+                    ):
                         new_title_val = st.session_state.chat_controller.generate_conversation_title(
                             current_history_for_title_gen, client
                         )
@@ -120,4 +137,3 @@ def render_chat_mode(safe_generate_gpt_response):
                 except Exception as e:
                     st.error(f"会話タイトル生成エラー: {e}")
         st.rerun()
-

--- a/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
+++ b/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
@@ -1,12 +1,16 @@
 import os
-import streamlit as st
 
+import streamlit as st
 
 DEFAULT_SIDEBAR_WIDTH = os.getenv("SIDEBAR_WIDTH", "18rem")
 # Allow the initial visibility to be configured so different deployments
 # can start with the sidebar expanded or collapsed. The value is treated
 # as a boolean where "1", "true" or "yes" enable the sidebar.
-DEFAULT_SIDEBAR_VISIBLE = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "false").lower() in {"1", "true", "yes"}
+DEFAULT_SIDEBAR_VISIBLE = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "false").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 
 
 def render_sidebar_toggle(
@@ -32,8 +36,18 @@ def render_sidebar_toggle(
     if "sidebar_visible" not in st.session_state:
         st.session_state["sidebar_visible"] = DEFAULT_SIDEBAR_VISIBLE
 
-    toggle_label = collapsed_label if not st.session_state.sidebar_visible else expanded_label
-    if st.button(toggle_label, key=key, help="サイドバーの表示切替"):
+    toggle_label = (
+        collapsed_label if not st.session_state.sidebar_visible else expanded_label
+    )
+    button_clicked = False
+    if st.session_state.sidebar_visible:
+        if st.sidebar.button(toggle_label, key=key, help="サイドバーを折りたたむ"):
+            button_clicked = True
+    else:
+        if st.button(toggle_label, key=key, help="サイドバーを表示"):
+            button_clicked = True
+
+    if button_clicked:
         st.session_state.sidebar_visible = not st.session_state.sidebar_visible
         st.rerun()
 

--- a/knowledgeplus_design-main/ui_modules/static/theme.css
+++ b/knowledgeplus_design-main/ui_modules/static/theme.css
@@ -44,6 +44,16 @@
         box-shadow: 0 4px 12px rgba(0, 113, 197, 0.1);
     }
 
+    /* Smaller header for compact layouts */
+    h1.app-title {
+        font-size: 1.25rem !important;
+        padding: 0.5rem !important;
+        margin-bottom: 1rem !important;
+        background: none !important;
+        border: none !important;
+        box-shadow: none !important;
+    }
+
     /* サブヘッダー */
     h2, h3 {
         color: var(--intel-blue) !important;

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -1,31 +1,22 @@
-import os
-import streamlit as st
 import logging
+import os
 import uuid
 from datetime import datetime
 
-from shared.env import load_env
-
-# Import shared modules
-from shared.upload_utils import ensure_openai_key, BASE_KNOWLEDGE_DIR
-from ui_modules.theme import apply_intel_theme
-from shared.chat_history_utils import (
-    load_chat_histories,
-    create_history,
-    append_message,
-    update_title,
-    delete_history,
-)
-from ui_modules.sidebar_toggle import render_sidebar_toggle
-from ui_modules.search_ui import render_search_mode
-from ui_modules.management_ui import render_management_mode
-from ui_modules.chat_ui import render_chat_mode
+import streamlit as st
 from shared.chat_controller import get_persona_list
-
-# Import functions from knowledge_gpt_app.app (some might be moved later)
-from shared.openai_utils import get_openai_client
-
-from config import DEFAULT_KB_NAME
+from shared.chat_history_utils import (
+    create_history,
+    delete_history,
+    load_chat_histories,
+)
+from shared.env import load_env
+from shared.upload_utils import ensure_openai_key
+from ui_modules.chat_ui import render_chat_mode
+from ui_modules.management_ui import render_management_mode
+from ui_modules.search_ui import render_search_mode
+from ui_modules.sidebar_toggle import render_sidebar_toggle
+from ui_modules.theme import apply_intel_theme
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +37,9 @@ sidebar_visible = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "false").lower() in {
     "yes",
 }
 initial_state = "expanded" if sidebar_visible else "collapsed"
-st.set_page_config(layout="wide", page_title="KNOWLEDGE+", initial_sidebar_state=initial_state)
+st.set_page_config(
+    layout="wide", page_title="KNOWLEDGE+", initial_sidebar_state=initial_state
+)
 
 apply_intel_theme(st)
 
@@ -59,6 +52,7 @@ render_sidebar_toggle(
     collapsed_label=TOGGLE_SIDEBAR_COLLAPSED,
     expanded_label=TOGGLE_SIDEBAR_EXPANDED,
 )
+
 
 def safe_generate_gpt_response(
     user_input,
@@ -84,9 +78,10 @@ def safe_generate_gpt_response(
         logger.error("GPT response generation error", exc_info=True)
         return None
 
+
 # --- Session State Initialization ---
 if "current_mode" not in st.session_state:
-    st.session_state["current_mode"] = "検索" # Default to Search mode
+    st.session_state["current_mode"] = "検索"  # Default to Search mode
 if "search_executed" not in st.session_state:
     st.session_state["search_executed"] = False
 if "chat_history" not in st.session_state:
@@ -128,17 +123,19 @@ mode_options = {
 }
 
 selected_mode_display = st.sidebar.radio(
-    "メニュー", 
-    list(mode_options.values()), 
+    "メニュー",
+    list(mode_options.values()),
     index=list(mode_options.keys()).index(st.session_state["current_mode"]),
     key="sidebar_mode_radio",
-    help="アプリケーションのモードを選択します。"
+    help="アプリケーションのモードを選択します。",
 )
 # Convert the selected display label back to the internal key. If the label is
 # not recognized (e.g. in tests that monkeypatch the sidebar), keep the
 # existing mode to avoid errors.
 if selected_mode_display in mode_options.values():
-    st.session_state["current_mode"] = list(mode_options.keys())[list(mode_options.values()).index(selected_mode_display)]
+    st.session_state["current_mode"] = list(mode_options.keys())[
+        list(mode_options.values()).index(selected_mode_display)
+    ]
 else:
     logger.warning("Invalid mode selection: %s", selected_mode_display)
 
@@ -149,22 +146,27 @@ sidebar = st.sidebar
 if hasattr(sidebar, "markdown"):
     sidebar.markdown("---")
 if hasattr(sidebar, "button") and sidebar.button("＋ 新しいチャット", key="new_chat_btn"):
-    new_id = create_history({
-        "persona": st.session_state.get("persona"),
-        "temperature": st.session_state.get("temperature"),
-        "prompt_advice": st.session_state.get("prompt_advice"),
-    })
+    new_id = create_history(
+        {
+            "persona": st.session_state.get("persona"),
+            "temperature": st.session_state.get("temperature"),
+            "prompt_advice": st.session_state.get("prompt_advice"),
+        }
+    )
     st.session_state.current_chat_id = new_id
     st.session_state.chat_history = []
     st.session_state.gpt_conversation_title = "新しい会話"
     st.session_state.title_generated = False
-    st.session_state.chat_histories.insert(0, {
-        "id": new_id,
-        "title": "新しい会話",
-        "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-        "settings": {},
-        "messages": [],
-    })
+    st.session_state.chat_histories.insert(
+        0,
+        {
+            "id": new_id,
+            "title": "新しい会話",
+            "created_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "settings": {},
+            "messages": [],
+        },
+    )
 
 if st.session_state.chat_histories and hasattr(sidebar, "expander"):
     with sidebar.expander("過去の会話", expanded=False):
@@ -203,7 +205,8 @@ if hasattr(sidebar, "expander"):
         persona_names = {p["id"]: p.get("name", p["id"]) for p in personas}
         current_id = st.session_state.get("persona", persona_ids[0])
         selected_id = st.selectbox(
-            "AIペルソナ", persona_ids,
+            "AIペルソナ",
+            persona_ids,
             index=persona_ids.index(current_id),
             format_func=lambda x: persona_names.get(x, x),
         )
@@ -220,7 +223,7 @@ if hasattr(sidebar, "expander"):
         )
 
 # --- Main Content Area based on Mode ---
-st.title("KNOWLEDGE+")  # Always show the main title
+st.markdown("<h1 class='app-title'>KNOWLEDGE+</h1>", unsafe_allow_html=True)
 
 if st.session_state["current_mode"] == "検索":
     render_search_mode(safe_generate_gpt_response)


### PR DESCRIPTION
## Summary
- adjust global theme with a smaller optional header style
- use the compact `app-title` style in `unified_app.py`
- enlarge chat container height for easier reading
- update sidebar toggle so it can collapse again from inside the sidebar

## Testing
- `pre-commit run --files knowledgeplus_design-main/ui_modules/static/theme.css knowledgeplus_design-main/unified_app.py knowledgeplus_design-main/ui_modules/chat_ui.py knowledgeplus_design-main/ui_modules/sidebar_toggle.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nltk')*

------
https://chatgpt.com/codex/tasks/task_e_686908b8f3888333a0dec1d51ba4e67c