### PR TITLE
Switch to mandatory PyMuPDF in file processor

### DIFF
--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -19,7 +19,7 @@ pip install -r requirements-extra.txt
 ```
 The `requirements-extra.txt` file holds large libraries such as **torch** and **transformers**.
 Installing them separately after the light requirements helps avoid network timeouts and keeps the initial setup lightweight.
-PyMuPDF and pytesseract are also included for PDF OCR support—install them if you need to process scanned PDFs.
+PyMuPDF is installed with the light requirements so PDF processing works out of the box. Install pytesseract as well if you need OCR for scanned PDFs.
 
 If `rank-bm25` fails to install during the above step, upgrade `pip` and install it manually:
 

--- a/knowledgeplus_design-main/docs/progress.md
+++ b/knowledgeplus_design-main/docs/progress.md
@@ -48,3 +48,9 @@
   break imports.
 - Image extraction tests now skip when Pillow isn't installed.
 - Confirmed the suite runs cleanly with and without optional packages.
+
+## 2025-07-12
+- Switched to mandatory PyMuPDF in `shared/file_processor.py` and removed old pdf2image checks.
+- PDF thumbnails now render via `fitz` directly.
+- Verified all 54 tests pass with `pytest -q`.
+

--- a/knowledgeplus_design-main/docs/progress.md
+++ b/knowledgeplus_design-main/docs/progress.md
@@ -54,3 +54,7 @@
 - PDF thumbnails now render via `fitz` directly.
 - Verified all 54 tests pass with `pytest -q`.
 
+## 2025-07-13
+- Added PyMuPDF to `requirements-light.txt` so CI installs it by default.
+- Updated README to note PyMuPDF is mandatory and pytesseract remains optional.
+

--- a/knowledgeplus_design-main/requirements-light.txt
+++ b/knowledgeplus_design-main/requirements-light.txt
@@ -5,6 +5,7 @@ requests>=2.32.3
 numpy>=1.24.0
 pandas>=2.0.0
 PyPDF2>=3.0.1
+PyMuPDF>=1.23.0
 python-docx>=1.1.2
 openpyxl>=3.1.5
 fpdf>=1.7.2

--- a/knowledgeplus_design-main/shared/file_processor.py
+++ b/knowledgeplus_design-main/shared/file_processor.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 from pathlib import Path
 from io import BytesIO
+import fitz  # PyMuPDF
 
 try:
     import docx  # python-docx
@@ -53,14 +54,7 @@ try:
 except ImportError:
     STEP_SUPPORT = False
 
-# PDF processing libraries
-try:
-    import fitz  # PyMuPDF
-    PDF_IMAGE_SUPPORT = True
-except ImportError:  # pragma: no cover - optional dependency
-    fitz = None
-    PDF_IMAGE_SUPPORT = False
-
+# PDF processing library is now a required dependency
 logger = logging.getLogger(__name__)
 
 
@@ -83,11 +77,7 @@ class FileProcessor:
     def _encode_image_to_base64(image_file):
         """画像ファイルをbase64エンコード"""
         try:
-            if (
-                PDF_IMAGE_SUPPORT
-                and hasattr(image_file, "type")
-                and image_file.type == "application/pdf"
-            ):
+            if hasattr(image_file, "type") and image_file.type == "application/pdf":
                 data = image_file.read()
                 pdf_doc = fitz.open(stream=data, filetype="pdf")
                 page = pdf_doc.load_page(0)
@@ -346,7 +336,7 @@ class FileProcessor:
                     page_text = page.extract_text()
                     if page_text:
                         text += page_text + "\n"
-                if PIL_SUPPORT and PDF_IMAGE_SUPPORT:
+                if PIL_SUPPORT:
                     pdf_doc = fitz.open(stream=data, filetype="pdf")
                     for page in pdf_doc:
                         pix = page.get_pixmap()


### PR DESCRIPTION
## Summary
- import `fitz` directly in `shared/file_processor.py`
- remove `PDF_IMAGE_SUPPORT` fallback logic
- simplify PDF handling conditions

## Testing
- `scripts/install_light.sh`
- `scripts/install_extra.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869292bf6088333afe43414adcb50df