### PR TITLE
Fix search input background

### DIFF
--- a/knowledgeplus_design-main/ui_modules/static/theme.css
+++ b/knowledgeplus_design-main/ui_modules/static/theme.css
@@ -400,6 +400,7 @@
         border-radius: 24px; /* Pill shape */
         padding: 10px 20px;
         box-shadow: none; /* Remove default Streamlit shadow */
+        background-color: transparent; /* Make input background transparent */
         transition: box-shadow 0.3s ease-in-out, border-color 0.3s ease-in-out;
     }
     [data-testid="stTextInput"] input:hover {


### PR DESCRIPTION
## Summary
- make search box background transparent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for nltk, fitz, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686b53f3421c83338d2688572970ae40