### PR TITLE
Add hybrid search weighting controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ You can override the default knowledge base name by setting
   export DEFAULT_KB_NAME=my_kb
   ```
 
+You can tune the default blend between vector similarity and keyword search by
+setting `HYBRID_VECTOR_WEIGHT` and `HYBRID_BM25_WEIGHT` before launching the
+app.  The values should sum to 1.0:
+
+  ```bash
+  export HYBRID_VECTOR_WEIGHT=0.7
+  export HYBRID_BM25_WEIGHT=0.3
+  ```
+
 These variables are evaluated when helper modules such as
 `upload_utils` and `chat_history_utils` are imported. Set them before
 running the application or tests so that all uploads and chat logs are

--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -56,6 +56,9 @@ streamlit run app.py
 会話タイトルを生成するモデルは `TITLE_MODEL` で上書きできます。たとえば `gpt-4o-mini` を使いたい場合は `export TITLE_MODEL=gpt-4o-mini` のように設定します。
 これらの値は `upload_utils` や `chat_history_utils`、`chat_controller` などのモジュール読み込み時に適用されます。アプリを起動する前に環境変数を設定しておくと、アップロードされたファイルや会話履歴、ペルソナ設定が指定したディレクトリに保存されます。
 
+ハイブリッド検索の重みは `HYBRID_VECTOR_WEIGHT` と `HYBRID_BM25_WEIGHT` で
+調整できます。値の合計は 1.0 になるよう設定してください。
+
 ## ✨ 主な機能
 
 *   **検索中心のUI**: Googleのようなシンプルで直感的なインターフェースで、必要な情報に素早くアクセスできます。

--- a/knowledgeplus_design-main/config.py
+++ b/knowledgeplus_design-main/config.py
@@ -12,3 +12,8 @@ DEFAULT_KB_NAME = os.getenv("DEFAULT_KB_NAME", "default_kb")
 # environment variable so deployments can switch to a different provider
 # such as Gemini.
 TITLE_GENERATION_MODEL = os.getenv("TITLE_MODEL", "gpt-3.5-turbo")
+
+# Default weights for the hybrid search engine. They can be overridden via
+# HYBRID_VECTOR_WEIGHT and HYBRID_BM25_WEIGHT environment variables.
+HYBRID_VECTOR_WEIGHT = float(os.getenv("HYBRID_VECTOR_WEIGHT", "0.7"))
+HYBRID_BM25_WEIGHT = float(os.getenv("HYBRID_BM25_WEIGHT", "0.3"))

--- a/knowledgeplus_design-main/knowledge_gpt_app/app.py
+++ b/knowledgeplus_design-main/knowledge_gpt_app/app.py
@@ -918,7 +918,15 @@ def expand_search_query(query, client=None):
         logger.error(f"クエリ拡張エラー: {e}", exc_info=True)
         return query
 
-def search_multiple_knowledge_bases(query, kb_names, top_k=5, threshold=0.15, client=None):
+def search_multiple_knowledge_bases(
+    query,
+    kb_names,
+    top_k=5,
+    threshold=0.15,
+    vector_weight=None,
+    bm25_weight=None,
+    client=None,
+):
     all_results = []
     not_found_overall = True
     if client is None:
@@ -934,7 +942,14 @@ def search_multiple_knowledge_bases(query, kb_names, top_k=5, threshold=0.15, cl
         engine = get_search_engine(kb_name)
         if engine:
             try:
-                results_for_kb, not_found_for_kb = engine.search(query, top_k=top_k, threshold=threshold, client=client)
+                results_for_kb, not_found_for_kb = engine.search(
+                    query,
+                    top_k=top_k,
+                    threshold=threshold,
+                    vector_weight=vector_weight,
+                    bm25_weight=bm25_weight,
+                    client=client,
+                )
                 if not not_found_for_kb and results_for_kb:
                     for r in results_for_kb: r['kb_name'] = kb_name
                     all_results.extend(results_for_kb)


### PR DESCRIPTION
## Summary
- add HYBRID_VECTOR_WEIGHT and HYBRID_BM25_WEIGHT defaults
- compute default weights based on KB size
- support overriding hybrid weights across search functions
- expose sliders in search and chat modes
- document new environment variables

## Testing
- `scripts/install_light.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871eac70cac8333ae7776deed04be9d