### PR TITLE
Enable batch embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ app.  The values should sum to 1.0:
   export HYBRID_BM25_WEIGHT=0.3
   ```
 
+Embedding requests are sent in batches of 10 by default. Adjust the batch size
+using `EMBEDDING_BATCH_SIZE` if you need to tune API throughput:
+
+  ```bash
+  export EMBEDDING_BATCH_SIZE=5
+  ```
+
 These variables are evaluated when helper modules such as
 `upload_utils` and `chat_history_utils` are imported. Set them before
 running the application or tests so that all uploads and chat logs are

--- a/knowledgeplus_design-main/config.py
+++ b/knowledgeplus_design-main/config.py
@@ -2,6 +2,7 @@ import os
 
 EMBEDDING_MODEL = "text-embedding-3-large"
 EMBEDDING_DIMENSIONS = 3072
+EMBEDDING_BATCH_SIZE = int(os.getenv("EMBEDDING_BATCH_SIZE", "10"))
 
 # Default knowledge base name can be overridden via the environment
 # to simplify customization in different deployments.

--- a/knowledgeplus_design-main/shared/openai_utils.py
+++ b/knowledgeplus_design-main/shared/openai_utils.py
@@ -2,7 +2,9 @@
 
 import logging
 
-from typing import Optional
+from typing import Optional, List
+
+from config import EMBEDDING_MODEL, EMBEDDING_DIMENSIONS
 
 from .upload_utils import ensure_openai_key
 from .errors import OpenAIClientError
@@ -43,3 +45,24 @@ except Exception:  # pragma: no cover - Streamlit not available
     def get_openai_client() -> Optional["OpenAI"]:
         """Return an OpenAI client or ``None`` if initialization fails."""
         return _create_client()
+
+
+def get_embeddings_batch(
+    texts: List[str],
+    client,
+    model: str = EMBEDDING_MODEL,
+    dimensions: int = EMBEDDING_DIMENSIONS,
+) -> List[List[float]]:
+    """Return embeddings for ``texts`` using a single API call."""
+    if client is None or not texts:
+        return []
+    try:
+        response = client.embeddings.create(
+            model=model,
+            input=texts,
+            dimensions=dimensions,
+        )
+        return [d.embedding for d in response.data]
+    except Exception as e:  # pragma: no cover - network issues
+        logger.error("Batch embedding error: %s", e)
+        return []

--- a/knowledgeplus_design-main/tests/test_kb_builder.py
+++ b/knowledgeplus_design-main/tests/test_kb_builder.py
@@ -19,14 +19,29 @@ class MockOpenAIClient:
 
 # Mock for OpenAI embeddings create method
 class MockEmbeddingsResponse:
-    def __init__(self, embedding_vector):
-        self.data = [MagicMock(embedding=embedding_vector)]
+    def __init__(self, embedding_vectors):
+        self.data = [MagicMock(embedding=v) for v in embedding_vectors]
 
 @pytest.fixture
 def mock_openai_client():
     client = MockOpenAIClient()
-    client.embeddings.create.return_value = MockEmbeddingsResponse([0.1] * 1536) # Default embedding
-    client.chat.completions.create.return_value = MagicMock(choices=[MagicMock(message=MagicMock(content='{"image_type": "図面", "main_content": "テスト", "keywords": ["テスト"], "description_for_search": "テスト"}'))])
+
+    def create(**kwargs):
+        inputs = kwargs.get("input")
+        if not isinstance(inputs, list):
+            inputs = [inputs]
+        return MockEmbeddingsResponse([[0.1] * 1536 for _ in inputs])
+
+    client.embeddings.create.side_effect = create
+    client.chat.completions.create.return_value = MagicMock(
+        choices=[
+            MagicMock(
+                message=MagicMock(
+                    content='{"image_type": "図面", "main_content": "テスト", "keywords": ["テスト"], "description_for_search": "テスト"}'
+                )
+            )
+        ]
+    )
     return client
 
 @pytest.fixture

--- a/knowledgeplus_design-main/tests/test_search_engine.py
+++ b/knowledgeplus_design-main/tests/test_search_engine.py
@@ -18,14 +18,20 @@ class MockOpenAIClient:
 
 # Mock for OpenAI embeddings create method
 class MockEmbeddingsResponse:
-    def __init__(self, embedding_vector):
-        self.data = [MagicMock(embedding=embedding_vector)]
+    def __init__(self, embedding_vectors):
+        self.data = [MagicMock(embedding=v) for v in embedding_vectors]
 
 @pytest.fixture
 def mock_openai_client():
     client = MockOpenAIClient()
     # Mock a consistent embedding for testing
-    client.embeddings.create.return_value = MockEmbeddingsResponse([0.5] * 1536) 
+    def create(**kwargs):
+        inputs = kwargs.get("input")
+        if not isinstance(inputs, list):
+            inputs = [inputs]
+        return MockEmbeddingsResponse([[0.5] * 1536 for _ in inputs])
+
+    client.embeddings.create.side_effect = create
     return client
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- add `EMBEDDING_BATCH_SIZE` to config
- implement `get_embeddings_batch` helper
- batch chunk embeddings in `KnowledgeBuilder`
- expose `get_embeddings_from_openai` for future multi-query search
- mock batch behavior in tests
- document batching via `EMBEDDING_BATCH_SIZE`

## Testing
- `scripts/install_light.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ef3524f883338698bbb150c69ace