### PR TITLE
Persist sidebar visibility

### DIFF
--- a/knowledgeplus_design-main/shared/ui_state.py
+++ b/knowledgeplus_design-main/shared/ui_state.py
@@ -1,0 +1,33 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+# Store UI state JSON alongside chat histories
+UI_STATE_FILE = Path(
+    os.getenv(
+        "UI_STATE_FILE",
+        str(Path(__file__).resolve().parents[2] / "chat_history" / "ui_state.json"),
+    )
+)
+
+
+def load_ui_state() -> Dict[str, Any]:
+    """Return the persisted UI state dictionary or an empty dict."""
+    if not UI_STATE_FILE.exists():
+        return {}
+    try:
+        with open(UI_STATE_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_ui_state(state: Dict[str, Any]) -> None:
+    """Persist the UI state to disk."""
+    UI_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(UI_STATE_FILE, "w", encoding="utf-8") as f:
+            json.dump(state, f, ensure_ascii=False, indent=2)
+    except Exception:
+        pass

--- a/knowledgeplus_design-main/tests/test_sidebar_toggle.py
+++ b/knowledgeplus_design-main/tests/test_sidebar_toggle.py
@@ -10,16 +10,27 @@ sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
 
 
 def test_sidebar_toggle_updates_state(monkeypatch):
-    calls = {"rerun": False}
+    calls = {"rerun": False, "saved": None, "params": None}
     monkeypatch.setattr(st, "button", lambda label, key=None, help=None: True)
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
     monkeypatch.setattr(st, "rerun", lambda: calls.__setitem__("rerun", True))
+    monkeypatch.setattr(st, "experimental_get_query_params", lambda: {})
+    monkeypatch.setattr(
+        st,
+        "experimental_set_query_params",
+        lambda **kw: calls.__setitem__("params", kw),
+    )
+    ui_state = importlib.import_module("shared.ui_state")
+    monkeypatch.setattr(ui_state, "load_ui_state", lambda: {})
+    monkeypatch.setattr(ui_state, "save_ui_state", lambda state: calls.__setitem__("saved", state))
     sidebar_toggle = importlib.import_module("ui_modules.sidebar_toggle")
 
     st.session_state.clear()
     sidebar_toggle.render_sidebar_toggle(key="test_toggle")
     assert st.session_state.get("sidebar_visible") is True
     assert calls["rerun"] is True
+    assert calls["params"] == {"sidebar": "1"}
+    assert calls["saved"] == {"sidebar_visible": True}
 
 
 def test_sidebar_toggle_custom_width(monkeypatch):
@@ -29,6 +40,11 @@ def test_sidebar_toggle_custom_width(monkeypatch):
     monkeypatch.setattr(
         st, "markdown", lambda text, **k: captured.setdefault("css", text)
     )
+    monkeypatch.setattr(st, "experimental_get_query_params", lambda: {})
+    monkeypatch.setattr(st, "experimental_set_query_params", lambda **kw: None)
+    ui_state = importlib.import_module("shared.ui_state")
+    monkeypatch.setattr(ui_state, "load_ui_state", lambda: {})
+    monkeypatch.setattr(ui_state, "save_ui_state", lambda state: None)
     sidebar_toggle = importlib.import_module("ui_modules.sidebar_toggle")
 
     st.session_state.clear()
@@ -40,6 +56,11 @@ def test_sidebar_toggle_initial_state_from_env(monkeypatch):
     monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
     monkeypatch.setattr(st, "rerun", lambda: None)
+    monkeypatch.setattr(st, "experimental_get_query_params", lambda: {})
+    monkeypatch.setattr(st, "experimental_set_query_params", lambda **kw: None)
+    ui_state = importlib.import_module("shared.ui_state")
+    monkeypatch.setattr(ui_state, "load_ui_state", lambda: {})
+    monkeypatch.setattr(ui_state, "save_ui_state", lambda state: None)
     monkeypatch.setenv("SIDEBAR_DEFAULT_VISIBLE", "true")
 
     # Reload module so the environment variable is read
@@ -50,3 +71,21 @@ def test_sidebar_toggle_initial_state_from_env(monkeypatch):
     st.session_state.clear()
     sidebar_toggle.render_sidebar_toggle(key="toggle_env")
     assert st.session_state.get("sidebar_visible") is True
+
+
+def test_sidebar_toggle_loads_from_file(monkeypatch):
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+    monkeypatch.setattr(st, "rerun", lambda: None)
+    monkeypatch.setattr(st, "experimental_get_query_params", lambda: {})
+    monkeypatch.setattr(st, "experimental_set_query_params", lambda **kw: None)
+    ui_state = importlib.import_module("shared.ui_state")
+    monkeypatch.setattr(ui_state, "load_ui_state", lambda: {"sidebar_visible": True})
+    monkeypatch.setattr(ui_state, "save_ui_state", lambda state: None)
+    if "ui_modules.sidebar_toggle" in sys.modules:
+        del sys.modules["ui_modules.sidebar_toggle"]
+    sidebar_toggle = importlib.import_module("ui_modules.sidebar_toggle")
+
+    st.session_state.clear()
+    sidebar_toggle.render_sidebar_toggle(key="load_file")
+    assert st.session_state.sidebar_visible is True

--- a/knowledgeplus_design-main/tests/test_ui_state.py
+++ b/knowledgeplus_design-main/tests/test_ui_state.py
@@ -1,0 +1,16 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+from shared import ui_state  # noqa: E402
+
+
+def test_load_and_save_ui_state(tmp_path, monkeypatch):
+    path = tmp_path / "ui.json"
+    monkeypatch.setattr(ui_state, "UI_STATE_FILE", path)
+    state = {"sidebar_visible": True}
+    ui_state.save_ui_state(state)
+    loaded = ui_state.load_ui_state()
+    assert loaded == state
+


### PR DESCRIPTION
## Summary
- persist sidebar visibility across sessions
- store UI state under `chat_history/ui_state.json`
- sync state with query params and add optional keyboard shortcut
- test sidebar toggle persistence
- add unit test for UI state helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872156ac58c8333bfbeff4e82a64b89