### PR TITLE
Add sidebar state persistence and keyboard shortcut

### DIFF
--- a/knowledgeplus_design-main/tests/test_sidebar_toggle.py
+++ b/knowledgeplus_design-main/tests/test_sidebar_toggle.py
@@ -9,12 +9,13 @@ import streamlit as st  # noqa: E402
 sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
 
 
-def test_sidebar_toggle_updates_state(monkeypatch):
+def test_sidebar_toggle_updates_state(tmp_path, monkeypatch):
     calls = {"rerun": False}
     monkeypatch.setattr(st, "button", lambda label, key=None, help=None: True)
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
     monkeypatch.setattr(st, "rerun", lambda: calls.__setitem__("rerun", True))
     sidebar_toggle = importlib.import_module("ui_modules.sidebar_toggle")
+    monkeypatch.setattr(sidebar_toggle, "SIDEBAR_STATE_PATH", tmp_path / "state.json")
 
     st.session_state.clear()
     sidebar_toggle.render_sidebar_toggle(key="test_toggle")
@@ -22,7 +23,7 @@ def test_sidebar_toggle_updates_state(monkeypatch):
     assert calls["rerun"] is True
 
 
-def test_sidebar_toggle_custom_width(monkeypatch):
+def test_sidebar_toggle_custom_width(tmp_path, monkeypatch):
     captured = {}
     monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "rerun", lambda: None)
@@ -30,13 +31,14 @@ def test_sidebar_toggle_custom_width(monkeypatch):
         st, "markdown", lambda text, **k: captured.setdefault("css", text)
     )
     sidebar_toggle = importlib.import_module("ui_modules.sidebar_toggle")
+    monkeypatch.setattr(sidebar_toggle, "SIDEBAR_STATE_PATH", tmp_path / "state.json")
 
     st.session_state.clear()
     sidebar_toggle.render_sidebar_toggle(key="toggle_w", sidebar_width="25rem")
     assert "25rem" in captured.get("css", "")
 
 
-def test_sidebar_toggle_initial_state_from_env(monkeypatch):
+def test_sidebar_toggle_initial_state_from_env(tmp_path, monkeypatch):
     monkeypatch.setattr(st, "button", lambda *a, **k: False)
     monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
     monkeypatch.setattr(st, "rerun", lambda: None)
@@ -46,7 +48,23 @@ def test_sidebar_toggle_initial_state_from_env(monkeypatch):
     if "ui_modules.sidebar_toggle" in sys.modules:
         del sys.modules["ui_modules.sidebar_toggle"]
     sidebar_toggle = importlib.import_module("ui_modules.sidebar_toggle")
+    monkeypatch.setattr(sidebar_toggle, "SIDEBAR_STATE_PATH", tmp_path / "state.json")
 
     st.session_state.clear()
     sidebar_toggle.render_sidebar_toggle(key="toggle_env")
+    assert st.session_state.get("sidebar_visible") is True
+
+
+def test_sidebar_toggle_loads_persisted_state(tmp_path, monkeypatch):
+    state_file = tmp_path / "sidebar_state.json"
+    state_file.write_text('{"visible": true}', encoding="utf-8")
+    monkeypatch.setattr(st, "button", lambda *a, **k: False)
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+    monkeypatch.setattr(st, "rerun", lambda: None)
+
+    sidebar_toggle = importlib.import_module("ui_modules.sidebar_toggle")
+    monkeypatch.setattr(sidebar_toggle, "SIDEBAR_STATE_PATH", state_file)
+
+    st.session_state.clear()
+    sidebar_toggle.render_sidebar_toggle(key="persist_load")
     assert st.session_state.get("sidebar_visible") is True

--- a/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
+++ b/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
@@ -1,6 +1,33 @@
+import json
 import os
 
 import streamlit as st
+from shared.chat_history_utils import CHAT_HISTORY_DIR
+
+SIDEBAR_STATE_PATH = CHAT_HISTORY_DIR / "sidebar_state.json"
+
+
+def _load_persisted_state() -> bool | None:
+    """Return saved visibility if the file exists else ``None``."""
+    if SIDEBAR_STATE_PATH.exists():
+        try:
+            with open(SIDEBAR_STATE_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return bool(data.get("visible"))
+        except Exception:
+            return None
+    return None
+
+
+def _save_persisted_state(visible: bool) -> None:
+    """Write the visibility flag to disk, ignoring errors."""
+    try:
+        SIDEBAR_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(SIDEBAR_STATE_PATH, "w", encoding="utf-8") as f:
+            json.dump({"visible": visible}, f)
+    except Exception:
+        pass
+
 
 DEFAULT_SIDEBAR_WIDTH = os.getenv("SIDEBAR_WIDTH", "18rem")
 # Allow the initial visibility to be configured so different deployments
@@ -34,7 +61,11 @@ def render_sidebar_toggle(
         the ``SIDEBAR_WIDTH`` environment variable to customize layouts.
     """
     if "sidebar_visible" not in st.session_state:
-        st.session_state["sidebar_visible"] = DEFAULT_SIDEBAR_VISIBLE
+        persisted = _load_persisted_state()
+        if persisted is None:
+            st.session_state["sidebar_visible"] = DEFAULT_SIDEBAR_VISIBLE
+        else:
+            st.session_state["sidebar_visible"] = persisted
 
     toggle_label = (
         collapsed_label if not st.session_state.sidebar_visible else expanded_label
@@ -54,6 +85,7 @@ def render_sidebar_toggle(
 
     if button_clicked:
         st.session_state.sidebar_visible = not st.session_state.sidebar_visible
+        _save_persisted_state(st.session_state.sidebar_visible)
         st.rerun()
 
     margin = "0" if st.session_state.sidebar_visible else f"-{sidebar_width}"
@@ -66,6 +98,14 @@ def render_sidebar_toggle(
             width: {sidebar_width};
         }}
         </style>
+        <script>
+        document.addEventListener('keydown', function(e) {{
+            if (e.ctrlKey && e.key === 'b') {{
+                var btn = document.getElementById('{key}');
+                if (btn) btn.click();
+            }}
+        }});
+        </script>
         """,
         unsafe_allow_html=True,
     )


### PR DESCRIPTION
## Summary
- allow `render_sidebar_toggle` to remember state across sessions
- toggle sidebar via Ctrl+B
- test persisted sidebar state loading

## Testing
- `pre-commit run --files knowledgeplus_design-main/ui_modules/sidebar_toggle.py knowledgeplus_design-main/tests/test_sidebar_toggle.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687248e9f3508333b5a54db71ff09b0d