### PR TITLE
Centralize PDF processing

### DIFF
--- a/knowledgeplus_design-main/knowledge_gpt_app/app.py
+++ b/knowledgeplus_design-main/knowledge_gpt_app/app.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, List
 
 import docx
 import pandas as pd
-import PyPDF2
 import streamlit as st
 from config import DEFAULT_KB_NAME, EMBEDDING_DIMENSIONS, EMBEDDING_MODEL
 from sudachipy import dictionary, tokenizer
@@ -39,6 +38,7 @@ import time
 import fitz  # PyMuPDF
 import pytesseract
 from generate_faq import generate_faqs_from_chunks
+from shared.file_processor import FileProcessor
 from shared.logging_utils import configure_logging
 from shared.openai_utils import get_openai_client
 from shared.upload_utils import BASE_KNOWLEDGE_DIR as SHARED_KB_DIR
@@ -260,12 +260,10 @@ def read_file(file):
     file_type = file.name.split(".")[-1].lower()
     try:
         if file_type == "pdf":
-            data = file.read()
-            file.seek(0)
+            pdf_reader, data = FileProcessor.load_pdf(file)
             with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as temp_file:
                 temp_file.write(data)
                 temp_path = temp_file.name
-            pdf_reader = PyPDF2.PdfReader(BytesIO(data))
             ocr_doc = None
             for idx, page in enumerate(pdf_reader.pages):
                 page_text = page.extract_text()

--- a/knowledgeplus_design-main/shared/file_processor.py
+++ b/knowledgeplus_design-main/shared/file_processor.py
@@ -100,6 +100,17 @@ class FileProcessor:
             return None
 
     @staticmethod
+    def load_pdf(file_obj):
+        """Return ``PyPDF2.PdfReader`` and raw bytes for ``file_obj``."""
+        if not PDF_TEXT_SUPPORT:
+            raise ImportError("PyPDF2 is required for PDF support")
+
+        data = file_obj.read()
+        file_obj.seek(0)
+        reader = PyPDF2.PdfReader(BytesIO(data))
+        return reader, data
+
+    @staticmethod
     def _process_dxf_file(dxf_file):
         """DXFファイルを処理して画像とメタデータを生成"""
         if not DXF_SUPPORT:

--- a/knowledgeplus_design-main/tests/test_import_warning.py
+++ b/knowledgeplus_design-main/tests/test_import_warning.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+import types
+import warnings
+from pathlib import Path
+
+import pytest
+
+STUBS_DIR = Path(__file__).resolve().parent / "stubs"
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+sys.modules.pop("numpy", None)
+if str(STUBS_DIR) in sys.path:
+    sys.path.remove(str(STUBS_DIR))
+if str(PROJECT_ROOT) in sys.path:
+    sys.path.remove(str(PROJECT_ROOT))
+np = importlib.import_module("numpy")
+
+sys.path.insert(0, str(STUBS_DIR))
+sys.path.insert(1, str(PROJECT_ROOT))
+
+if not hasattr(np, "__version__"):
+    np.__version__ = "1.24.0"
+
+sys.modules.setdefault(
+    "sentence_transformers",
+    types.SimpleNamespace(SentenceTransformer=lambda *a, **k: object()),
+)
+
+pytest.importorskip("streamlit")
+pytest.importorskip("sudachipy")
+
+
+def test_app_import_warns_once(monkeypatch):
+    sys.modules.setdefault("pandas", types.SimpleNamespace())
+    tokenize_mod = types.ModuleType("nltk.tokenize")
+    tokenize_mod.word_tokenize = lambda t: t.split()
+    nltk_mod = types.ModuleType("nltk")
+    nltk_mod.tokenize = tokenize_mod
+    sys.modules.setdefault("nltk", nltk_mod)
+    sys.modules.setdefault("nltk.tokenize", tokenize_mod)
+
+    warnings_called = []
+
+    def fake_warn(*args, **kwargs):
+        msg = kwargs.get("message", args[0] if args else None)
+        warnings_called.append(msg)
+
+    monkeypatch.setattr(warnings, "warn", fake_warn)
+    if str(STUBS_DIR) in sys.path:
+        sys.path.remove(str(STUBS_DIR))
+    sys.modules.pop("knowledge_gpt_app.app", None)
+    importlib.import_module("knowledge_gpt_app.app")
+    sys.path.insert(0, str(STUBS_DIR))
+
+    msgs = [m for m in warnings_called if m and "PyPDF2" in str(m)]
+    assert len(msgs) <= 1


### PR DESCRIPTION
## Summary
- centralize pdf loading utilities in `shared.file_processor`
- update `knowledge_gpt_app` to use the shared helper
- add regression test ensuring app import emits at most one PyPDF2 warning

## Testing
- `pre-commit run --files knowledgeplus_design-main/knowledge_gpt_app/app.py knowledgeplus_design-main/shared/file_processor.py knowledgeplus_design-main/tests/test_import_warning.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68725066fbc883339f945b98780c5e5b