### PR TITLE
Implement image preview and download support

### DIFF
--- a/knowledgeplus_design-main/tests/test_document_card.py
+++ b/knowledgeplus_design-main/tests/test_document_card.py
@@ -1,3 +1,4 @@
+import base64
 import importlib
 import sys
 from pathlib import Path
@@ -21,3 +22,49 @@ def test_render_document_card_outputs_html(monkeypatch):
     assert outputs
     assert "foo" in outputs[0]
     assert "Score" in outputs[0]
+
+
+def test_render_document_card_image_and_download(tmp_path, monkeypatch):
+    outputs = []
+    images = []
+    downloads = []
+    monkeypatch.setattr(
+        st, "markdown", lambda text, unsafe_allow_html=False: outputs.append(text)
+    )
+    monkeypatch.setattr(st, "image", lambda *a, **k: images.append(True))
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: downloads.append(True))
+
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("x")
+
+    mod = importlib.import_module("ui_modules.document_card")
+    doc = {
+        "metadata": {
+            "title": "foo",
+            "preview_image": base64.b64encode(b"img").decode("utf-8"),
+            "paths": {"original_file_path": str(file_path)},
+        },
+        "text": "hello world",
+        "similarity": 0.5,
+    }
+    mod.render_document_card(doc)
+    assert images
+    assert downloads
+
+
+def test_render_document_card_missing_file(monkeypatch):
+    errors = []
+    monkeypatch.setattr(st, "markdown", lambda *a, **k: None)
+    monkeypatch.setattr(st, "image", lambda *a, **k: None)
+    monkeypatch.setattr(st, "download_button", lambda *a, **k: None)
+    monkeypatch.setattr(st, "error", lambda msg: errors.append(msg))
+
+    mod = importlib.import_module("ui_modules.document_card")
+    doc = {
+        "metadata": {"title": "foo", "paths": {"original_file_path": "none"}},
+        "text": "hello",
+        "similarity": 0.1,
+    }
+    mod.render_document_card(doc)
+    assert errors
+    assert "リンク先に存在しません" in errors[0]

--- a/knowledgeplus_design-main/ui_modules/document_card.py
+++ b/knowledgeplus_design-main/ui_modules/document_card.py
@@ -1,4 +1,6 @@
+import base64
 from html import escape
+from pathlib import Path
 from typing import Any, Dict
 
 import streamlit as st
@@ -15,8 +17,32 @@ def render_document_card(doc: Dict[str, Any]) -> None:
     )
     snippet = doc.get("text", "")[:120].replace("\n", " ")
     similarity = doc.get("similarity")
+
+    preview_b64 = meta.get("preview_image")
+    image_path = meta.get("paths", {}).get("image_path")
+    if preview_b64:
+        try:
+            img_bytes = base64.b64decode(preview_b64)
+            st.image(img_bytes, use_container_width=True)
+        except Exception:
+            pass
+    elif image_path and Path(image_path).exists():
+        st.image(image_path, use_container_width=True)
+
     body = f"<div class='doc-card'><strong>{escape(title)}</strong>"
     if similarity is not None:
         body += f"<div>Score: {similarity:.3f}</div>"
     body += f"<div>{escape(snippet)}...</div></div>"
     st.markdown(body, unsafe_allow_html=True)
+
+    file_path = meta.get("paths", {}).get("original_file_path")
+    if file_path:
+        file = Path(file_path)
+        if file.exists():
+            st.download_button(
+                label="画像ダウンロード",
+                data=file.read_bytes(),
+                file_name=file.name,
+            )
+        else:
+            st.error("データ取得時から移動されており、リンク先に存在しません")


### PR DESCRIPTION
## Summary
- display preview images when available in search results
- show download button for stored file and report if missing
- add tests for image preview and file download logic

## Testing
- `scripts/install_light.sh`
- `scripts/install_extra.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874dcfffbd48333bfa9d6b1090ae5d5