### PR TITLE
Add sidebar persistence note

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ sidebar open when the app starts:
   export SIDEBAR_DEFAULT_VISIBLE=true
   ```
 
+The last sidebar state is saved to `chat_history/sidebar_state.json`. If the
+sidebar keeps reappearing, delete this file or start the app with
+`SIDEBAR_DEFAULT_VISIBLE=false` to reset it. The default value is `false` so
+omitting the variable collapses the sidebar at startup.
+
 You can override the default knowledge base name by setting
 `DEFAULT_KB_NAME` before running the app:
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -31,6 +31,8 @@ run_app.bat           # Windows
 export SIDEBAR_DEFAULT_VISIBLE=true
 ```
 
+サイドバーの状態は `chat_history/sidebar_state.json` に保存されます。折りたたんでも再表示される場合は、このファイルを削除するか `SIDEBAR_DEFAULT_VISIBLE=false` を設定して起動してください。デフォルト値は `false` です。
+
 ## 保存先ディレクトリの変更
 
 デフォルトでは `knowledge_base/` にファイルやメタデータが保存されます。保存場所を変更する場合は以下の環境変数を設定してください。


### PR DESCRIPTION
## Summary
- mention that sidebar visibility is saved under `chat_history/sidebar_state.json`
- explain how to reset the persisted sidebar state in English and Japanese guides

## Testing
- `pre-commit run --files $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875ac3b73908333896a0316df1650c0