### PR TITLE
Show sidebar by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,18 @@ You can similarly override where chat histories are stored by setting
   export CHAT_HISTORY_DIR=/path/to/chat_history
   ```
 
-The sidebar defaults to collapsed. Use the `<<` or `>>` button to expand or
-collapse it. Set `SIDEBAR_DEFAULT_VISIBLE=true` before launching to keep the
-sidebar open when the app starts:
+The sidebar defaults to expanded. Use the `<<` or `>>` button to collapse or
+expand it. Set `SIDEBAR_DEFAULT_VISIBLE=false` before launching if you prefer
+the sidebar hidden at startup:
 
   ```bash
-  export SIDEBAR_DEFAULT_VISIBLE=true
+  export SIDEBAR_DEFAULT_VISIBLE=false
   ```
 
 The last sidebar state is saved to `chat_history/sidebar_state.json`. If the
 sidebar keeps reappearing, delete this file or start the app with
-`SIDEBAR_DEFAULT_VISIBLE=false` to reset it. The default value is `false` so
-omitting the variable collapses the sidebar at startup.
+`SIDEBAR_DEFAULT_VISIBLE=false` to reset it. The default value is `true` so
+omitting the variable keeps the sidebar visible when the app starts.
 
 You can override the default knowledge base name by setting
 `DEFAULT_KB_NAME` before running the app:

--- a/README_JA.md
+++ b/README_JA.md
@@ -25,13 +25,13 @@ run_app.bat           # Windows
 
 起動後、ブラウザから表示されるインターフェースで PDF、Word、画像、CAD などのファイルをアップロードし、ナレッジベースを構築できます。チャット画面ではアップロードしたドキュメントの内容を参照しながら質問が可能です。
 
-デフォルトではサイドバーは折りたたまれた状態で起動します。常に表示させたい場合は起動前に次の環境変数を設定してください。
+デフォルトではサイドバーは表示された状態で起動します。折りたたんだ状態で開始したい場合は起動前に次の環境変数を設定してください。
 
 ```bash
-export SIDEBAR_DEFAULT_VISIBLE=true
+export SIDEBAR_DEFAULT_VISIBLE=false
 ```
 
-サイドバーの状態は `chat_history/sidebar_state.json` に保存されます。折りたたんでも再表示される場合は、このファイルを削除するか `SIDEBAR_DEFAULT_VISIBLE=false` を設定して起動してください。デフォルト値は `false` です。
+サイドバーの状態は `chat_history/sidebar_state.json` に保存されます。再表示されたくない場合は、このファイルを削除するか `SIDEBAR_DEFAULT_VISIBLE=false` を設定して起動してください。デフォルト値は `true` です。
 
 ## 保存先ディレクトリの変更
 

--- a/knowledgeplus_design-main/tests/test_sidebar_toggle.py
+++ b/knowledgeplus_design-main/tests/test_sidebar_toggle.py
@@ -18,6 +18,7 @@ def test_sidebar_toggle_updates_state(tmp_path, monkeypatch):
     monkeypatch.setattr(sidebar_toggle, "SIDEBAR_STATE_PATH", tmp_path / "state.json")
 
     st.session_state.clear()
+    st.session_state["sidebar_visible"] = False
     sidebar_toggle.render_sidebar_toggle(key="test_toggle")
     assert st.session_state.get("sidebar_visible") is True
     assert calls["rerun"] is True

--- a/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
+++ b/knowledgeplus_design-main/ui_modules/sidebar_toggle.py
@@ -33,7 +33,8 @@ DEFAULT_SIDEBAR_WIDTH = os.getenv("SIDEBAR_WIDTH", "18rem")
 # Allow the initial visibility to be configured so different deployments
 # can start with the sidebar expanded or collapsed. The value is treated
 # as a boolean where "1", "true" or "yes" enable the sidebar.
-DEFAULT_SIDEBAR_VISIBLE = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "false").lower() in {
+# Start with the sidebar expanded unless the environment variable is set to disable it
+DEFAULT_SIDEBAR_VISIBLE = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "true").lower() in {
     "1",
     "true",
     "yes",

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -31,7 +31,8 @@ except Exception as e:
     st.stop()
 
 # Global page config and styling
-sidebar_visible = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "false").lower() in {
+# Default to showing the sidebar unless explicitly disabled
+sidebar_visible = os.getenv("SIDEBAR_DEFAULT_VISIBLE", "true").lower() in {
     "1",
     "true",
     "yes",


### PR DESCRIPTION
## Summary
- default the sidebar to expanded on startup
- update toggler tests for new default state
- document new behavior in README and README_JA

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875d73bdce88333a41495e5177c2ad2