### PR TITLE
Update sidebar names and hide weight slider

### DIFF
--- a/knowledgeplus_design-main/shared/chat_history_utils.py
+++ b/knowledgeplus_design-main/shared/chat_history_utils.py
@@ -42,7 +42,9 @@ def load_chat_histories() -> List[Dict]:
             )
         except Exception:
             continue
-    histories.sort(key=lambda h: h.get("created_at", ""), reverse=True)
+    # ``created_at`` may be ``None`` if older history files are missing
+    # the field. Use an empty string fallback so sorting does not error.
+    histories.sort(key=lambda h: h.get("created_at") or "", reverse=True)
     return histories
 
 

--- a/knowledgeplus_design-main/ui_modules/chat_ui.py
+++ b/knowledgeplus_design-main/ui_modules/chat_ui.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from config import DEFAULT_KB_NAME, HYBRID_VECTOR_WEIGHT
+from config import DEFAULT_KB_NAME, HYBRID_BM25_WEIGHT, HYBRID_VECTOR_WEIGHT
 from knowledge_gpt_app.app import search_multiple_knowledge_bases
 from shared.chat_controller import ChatController
 from shared.chat_history_utils import append_message, update_title
@@ -11,20 +11,14 @@ from shared.upload_utils import BASE_KNOWLEDGE_DIR
 
 def render_chat_mode(safe_generate_gpt_response):
     """Render the chat interface."""
-    st.subheader("チャット")
+    st.subheader("chatGPT")
     # Display current conversation title underneath the header
     st.markdown(f"### {st.session_state.get('gpt_conversation_title', '新しい会話')}")
     use_kb = st.session_state.get("use_knowledge_search", True)
 
-    vec_weight = st.slider(
-        "ベクトル重み",
-        0.0,
-        1.0,
-        HYBRID_VECTOR_WEIGHT,
-        0.05,
-        help="チャット時のハイブリッド検索で使用するベクトルスコアの比率。",
-    )
-    bm25_weight = 1.0 - vec_weight
+    # Use configured search weights without showing the slider
+    vec_weight = HYBRID_VECTOR_WEIGHT
+    bm25_weight = HYBRID_BM25_WEIGHT
 
     chat_container = st.container(height=700)
     with chat_container:

--- a/knowledgeplus_design-main/ui_modules/search_ui.py
+++ b/knowledgeplus_design-main/ui_modules/search_ui.py
@@ -7,6 +7,7 @@ from ui_modules.document_card import render_document_card
 
 def render_search_mode(safe_generate_gpt_response):
     """Refactored search interface with a clean layout and simplified controls."""
+    st.subheader("ナレッジ検索")
 
     # Apply custom CSS for buttons
     st.markdown(

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -118,11 +118,11 @@ if "current_chat_id" not in st.session_state:
         st.session_state["current_chat_id"] = create_history({})
 
 # --- Sidebar Navigation ---
-# Use a key to persist selection and add emoji icons
+# Use a key to persist selection and keep labels consistent across screens
 mode_options = {
-    "検索": "検索",
+    "チャット": "chatGPT",
+    "検索": "ナレッジ検索",
     "管理": "管理",
-    "チャット": "チャット",
 }
 
 selected_mode_display = st.sidebar.radio(


### PR DESCRIPTION
## Summary
- reorder sidebar menu and rename items
- rename chat screen heading and drop weighting slider
- display "ナレッジ検索" heading on the search screen

## Testing
- `pre-commit run --files knowledgeplus_design-main/ui_modules/chat_ui.py knowledgeplus_design-main/ui_modules/search_ui.py knowledgeplus_design-main/unified_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765271e4f88333951a878dc648c03b