### PR TITLE
Fix checkbox checkmark color

### DIFF
--- a/knowledgeplus_design-main/ui_modules/static/theme.css
+++ b/knowledgeplus_design-main/ui_modules/static/theme.css
@@ -217,6 +217,11 @@ button#toggle_sidebar p {
         background-color: var(--intel-blue);
     }
 
+    .stCheckbox > label svg {
+        stroke: #000 !important;
+        color: #000 !important; /* fallback */
+    }
+
     /* エキスパンダー */
     .streamlit-expanderHeader {
         background: var(--intel-light-gray);


### PR DESCRIPTION
## Summary
- update `theme.css` so checked checkbox icons are black

## Testing
- `pre-commit run --files knowledgeplus_design-main/ui_modules/static/theme.css`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765b00a1948333a6b0cb040101493b