### PR TITLE
Fix knowledge base default path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ treated as an error.
   ```
   - Optionally edit `KNOWLEDGE_BASE_DIR` and `CHAT_HISTORY_DIR` in `.env` to change where data is stored.
 
-You can also override the default `knowledge_base/` directory location by setting `KNOWLEDGE_BASE_DIR` before running the app:
+The application stores data under `knowledge_base/` at the repository root by default. You can override this location by setting `KNOWLEDGE_BASE_DIR` before running the app:
 
   ```bash
   export KNOWLEDGE_BASE_DIR=/path/to/storage

--- a/README_JA.md
+++ b/README_JA.md
@@ -35,7 +35,7 @@ export SIDEBAR_DEFAULT_VISIBLE=false
 
 ## 保存先ディレクトリの変更
 
-デフォルトでは `knowledge_base/` にファイルやメタデータが保存されます。保存場所を変更する場合は以下の環境変数を設定してください。
+デフォルトではリポジトリのルートにある `knowledge_base/` フォルダにファイルやメタデータが保存されます。保存場所を変更する場合は以下の環境変数を設定してください。
 
 - `KNOWLEDGE_BASE_DIR` – ナレッジベースの保存先
 - `CHAT_HISTORY_DIR` – チャット履歴の保存先

--- a/knowledgeplus_design-main/shared/search_engine.py
+++ b/knowledgeplus_design-main/shared/search_engine.py
@@ -936,7 +936,7 @@ def search_knowledge_base(
 if __name__ == "__main__":
     logger.info("knowledge_search.py を直接実行します (テストモード)")
     script_dir = Path(__file__).resolve().parent
-    default_test_kb_relative_path = f"../knowledge_base/{DEFAULT_KB_NAME}"
+    default_test_kb_relative_path = f"../../knowledge_base/{DEFAULT_KB_NAME}"
     test_kb_full_path = (script_dir / default_test_kb_relative_path).resolve()
     logger.info(f"テスト用ナレッジベースのパス: {test_kb_full_path}")
     if not test_kb_full_path.exists() or not test_kb_full_path.is_dir():

--- a/knowledgeplus_design-main/shared/upload_utils.py
+++ b/knowledgeplus_design-main/shared/upload_utils.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 # Base directory for all knowledge bases. Allow override via environment variable
-_default_base = Path(__file__).resolve().parent.parent / "knowledge_base"
+_default_base = Path(__file__).resolve().parents[2] / "knowledge_base"
 BASE_KNOWLEDGE_DIR = Path(os.getenv("KNOWLEDGE_BASE_DIR", _default_base))
 BASE_KNOWLEDGE_DIR.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- update `_default_base` to use the repository root
- adjust search engine test path logic
- clarify default storage location in the English and Japanese READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f20487008333b9f09479db674c2f