### PR TITLE
Fix file upload result handling

### DIFF
--- a/knowledgeplus_design-main/tests/test_management_integration.py
+++ b/knowledgeplus_design-main/tests/test_management_integration.py
@@ -60,7 +60,11 @@ def test_render_management_mode_mixed_files(monkeypatch):
     monkeypatch.setattr(management_ui, "display_thumbnail_grid", lambda *a, **k: None)
 
     def fake_process_file(cls, uploaded_file):
-        return (f"b64_{uploaded_file.name}", {})
+        return {
+            "image_base64": f"b64_{uploaded_file.name}",
+            "metadata": {},
+            "type": "image",
+        }
 
     monkeypatch.setattr(
         management_ui.FileProcessor, "process_file", classmethod(fake_process_file)

--- a/knowledgeplus_design-main/ui_modules/management_ui.py
+++ b/knowledgeplus_design-main/ui_modules/management_ui.py
@@ -66,9 +66,11 @@ def render_management_mode():
 
                         try:
                             with st.spinner(progress_text):
-                                image_b64, cad_meta = file_processor.process_file(
+                                processed_data = file_processor.process_file(
                                     uploaded_file
                                 )
+                                image_b64 = processed_data.get("image_base64")
+                                cad_meta = processed_data.get("metadata")
 
                                 if not image_b64:
                                     st.error(f"ファイルの処理に失敗しました: {file_name}")


### PR DESCRIPTION
## Summary
- handle dictionary result in `management_ui` when processing uploads
- update integration test to match dict return type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687723b02eb48333a3e1c7308ed48685