### PR TITLE
Add CLIP utilities for image embeddings

### DIFF
--- a/knowledgeplus_design-main/core/mm_builder_utils.py
+++ b/knowledgeplus_design-main/core/mm_builder_utils.py
@@ -1,14 +1,12 @@
 import json
 import logging
-from typing import Optional
-
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
+import config
 from shared.file_processor import FileProcessor
 from shared.kb_builder import KnowledgeBuilder
 from shared.openai_utils import get_openai_client
-import config
 
 logger = logging.getLogger(__name__)
 

--- a/knowledgeplus_design-main/core/mm_builder_utils.py
+++ b/knowledgeplus_design-main/core/mm_builder_utils.py
@@ -2,9 +2,13 @@ import json
 import logging
 from typing import Optional
 
+from pathlib import Path
+from typing import Tuple
+
 from shared.file_processor import FileProcessor
 from shared.kb_builder import KnowledgeBuilder
 from shared.openai_utils import get_openai_client
+import config
 
 logger = logging.getLogger(__name__)
 
@@ -150,3 +154,46 @@ JSON形式で返してください。日本語で回答してください。
     except Exception as e:
         logger.error(f"GPT-4o画像解析エラー: {e}")
         return {"error": f"画像解析中にエラーが発生しました: {e}"}
+
+
+# --- CLIP model utilities ---
+_clip_model = None
+_clip_processor = None
+
+
+def load_model_and_processor() -> Tuple[object, object]:
+    """Load and cache the CLIP model and processor.
+
+    Returns the model and processor instances. They are loaded lazily from
+    ``config.MULTIMODAL_MODEL`` and cached for future calls.
+    """
+    global _clip_model, _clip_processor
+    if _clip_model is None or _clip_processor is None:
+        from transformers import CLIPModel, CLIPProcessor
+
+        _clip_model = CLIPModel.from_pretrained(config.MULTIMODAL_MODEL)
+        _clip_processor = CLIPProcessor.from_pretrained(config.MULTIMODAL_MODEL)
+    return _clip_model, _clip_processor
+
+
+def get_image_embedding(image, model=None, processor=None) -> list[float]:
+    """Return an embedding vector for ``image`` using the CLIP model."""
+
+    if model is None or processor is None:
+        model, processor = load_model_and_processor()
+
+    if isinstance(image, (str, Path)):
+        from PIL import Image
+
+        img = Image.open(image)
+    else:
+        img = image
+
+    inputs = processor(images=img, return_tensors="pt")
+    features = model.get_image_features(**inputs)
+    if hasattr(features, "detach"):
+        features = features.detach()
+    if hasattr(features, "cpu"):
+        features = features.cpu()
+    vector = features[0].tolist()
+    return vector[: config.EMBEDDING_DIM]

--- a/knowledgeplus_design-main/tests/test_mm_builder_utils.py
+++ b/knowledgeplus_design-main/tests/test_mm_builder_utils.py
@@ -50,3 +50,79 @@ def test_get_embedding_handles_timeout(monkeypatch):
 
     result = mm_builder_utils.get_embedding("hello")
     assert result is None
+
+
+def test_load_model_and_processor_caches(monkeypatch):
+    calls = {"model": 0, "processor": 0}
+
+    class DummyModel:
+        pass
+
+    class DummyProcessor:
+        pass
+
+    def fake_model(name):
+        calls["model"] += 1
+        return DummyModel()
+
+    def fake_processor(name):
+        calls["processor"] += 1
+        return DummyProcessor()
+
+    dummy_transformers = types.SimpleNamespace(
+        CLIPModel=types.SimpleNamespace(from_pretrained=fake_model),
+        CLIPProcessor=types.SimpleNamespace(from_pretrained=fake_processor),
+    )
+    monkeypatch.setitem(sys.modules, "transformers", dummy_transformers)
+
+    mm_builder_utils._clip_model = None
+    mm_builder_utils._clip_processor = None
+
+    m1, p1 = mm_builder_utils.load_model_and_processor()
+    m2, p2 = mm_builder_utils.load_model_and_processor()
+
+    assert isinstance(m1, DummyModel)
+    assert isinstance(p1, DummyProcessor)
+    assert m1 is m2
+    assert p1 is p2
+    assert calls["model"] == 1
+    assert calls["processor"] == 1
+
+
+def test_get_image_embedding(monkeypatch):
+    expected = [0.1] * mm_builder_utils.config.EMBEDDING_DIM
+
+    class DummyFeatures:
+        def __init__(self, vec):
+            self.vec = vec
+
+        def detach(self):
+            return self
+
+        def cpu(self):
+            return self
+
+        def __getitem__(self, idx):
+            return DummyList(self.vec)
+
+
+    class DummyList(list):
+        def tolist(self):
+            return list(self)
+
+    class DummyModel:
+        def get_image_features(self, **kwargs):
+            return DummyFeatures(expected)
+
+    class DummyProcessor:
+        def __call__(self, images, return_tensors="pt"):
+            return {"dummy": True}
+
+    monkeypatch.setattr(
+        mm_builder_utils,
+        "load_model_and_processor",
+        lambda: (DummyModel(), DummyProcessor()),
+    )
+
+    result = mm_builder_utils.get_image_embedding(object())
+    assert result == expected

--- a/knowledgeplus_design-main/tests/test_mm_builder_utils.py
+++ b/knowledgeplus_design-main/tests/test_mm_builder_utils.py
@@ -105,7 +105,6 @@ def test_get_image_embedding(monkeypatch):
         def __getitem__(self, idx):
             return DummyList(self.vec)
 
-
     class DummyList(list):
         def tolist(self):
             return list(self)


### PR DESCRIPTION
## Summary
- add `load_model_and_processor` and `get_image_embedding` helpers in `core/mm_builder_utils.py`
- test the new utilities

## Testing
- `pytest -q knowledgeplus_design-main/tests/test_mm_builder_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68772b9bae288333a37486ac53f2991d