### PR TITLE
Handle image chunk text

### DIFF
--- a/knowledgeplus_design-main/shared/file_processor.py
+++ b/knowledgeplus_design-main/shared/file_processor.py
@@ -448,8 +448,12 @@ class FileProcessor:
                 embedding = KnowledgeBuilder.generate_image_embedding(img_bytes)
                 if embedding is not None:
                     chunk_id = str(uuid.uuid4())
+                    chunk_text = Path(file.name).name
                     upload_utils.save_processed_data(
-                        kb_name, chunk_id, embedding=embedding
+                        kb_name,
+                        chunk_id,
+                        chunk_text=chunk_text,
+                        embedding=embedding,
                     )
             except Exception as e:  # pragma: no cover - optional deps missing
                 logger.error("画像ベクトル保存エラー: %s", e)

--- a/knowledgeplus_design-main/tests/test_file_processor_embeddings.py
+++ b/knowledgeplus_design-main/tests/test_file_processor_embeddings.py
@@ -38,6 +38,10 @@ def test_process_image_saves_embedding(tmp_path, monkeypatch):
     assert len(files) == 1
     data = pickle.loads(files[0].read_bytes())
     assert data["embedding"] == [0.1, 0.2]
+    chunk_dir = tmp_path / "kb1" / "chunks"
+    chunks = list(chunk_dir.glob("*.txt"))
+    assert len(chunks) == 1
+    assert chunks[0].read_text(encoding="utf-8") == "img.png"
 
 
 def test_process_document_saves_embedding(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add chunk text when processing images
- test that image processing stores embedding and chunk name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68778436ec4c8333bf991f546a095b03