### PR TITLE
Cache CLIP model per builder

### DIFF
--- a/knowledgeplus_design-main/core/mm_builder_utils.py
+++ b/knowledgeplus_design-main/core/mm_builder_utils.py
@@ -10,12 +10,6 @@ from shared.openai_utils import get_openai_client
 
 logger = logging.getLogger(__name__)
 
-_file_processor = FileProcessor()
-_kb_builder = KnowledgeBuilder(
-    _file_processor,
-    get_openai_client_func=get_openai_client,
-    refresh_search_engine_func=None,
-)
 
 
 def get_embedding(text: str, client=None):
@@ -195,3 +189,12 @@ def get_image_embedding(image, model=None, processor=None) -> list[float]:
         features = features.cpu()
     vector = features[0].tolist()
     return vector[: config.EMBEDDING_DIM]
+
+
+# Initialize a default KnowledgeBuilder for convenience
+_file_processor = FileProcessor()
+_kb_builder = KnowledgeBuilder(
+    _file_processor,
+    get_openai_client_func=get_openai_client,
+    refresh_search_engine_func=None,
+)

--- a/knowledgeplus_design-main/mm_kb_builder/app.py
+++ b/knowledgeplus_design-main/mm_kb_builder/app.py
@@ -160,7 +160,8 @@ with tab1:
                     is_cad_file = file_extension in SUPPORTED_CAD_TYPES
 
                     image_base64, cad_metadata = _file_processor.process_file(
-                        uploaded_file
+                        uploaded_file,
+                        builder=_kb_builder,
                     )
 
                     if image_base64 is None:

--- a/knowledgeplus_design-main/shared/kb_builder.py
+++ b/knowledgeplus_design-main/shared/kb_builder.py
@@ -31,12 +31,21 @@ class KnowledgeBuilder:
         self.file_processor = file_processor
         self.get_openai_client = get_openai_client_func
         self.refresh_search_engine = refresh_search_engine_func
+        try:
+            from core import mm_builder_utils
+
+            self.clip_model, self.clip_processor = (
+                mm_builder_utils.load_model_and_processor()
+            )
+        except Exception as e:  # pragma: no cover - heavy deps may be missing
+            logger.error("CLIPモデル読み込みエラー: %s", e)
+            self.clip_model = None
+            self.clip_processor = None
 
     # --------------------------------------------------
     # Embedding helpers
     # --------------------------------------------------
-    @staticmethod
-    def generate_image_embedding(image_bytes: bytes) -> Optional[list[float]]:
+    def generate_image_embedding(self, image_bytes: bytes) -> Optional[list[float]]:
         """Return an embedding vector for the given image bytes."""
         try:
             from PIL import Image  # type: ignore
@@ -49,13 +58,14 @@ class KnowledgeBuilder:
         try:
             from core import mm_builder_utils
 
-            return mm_builder_utils.get_image_embedding(img)
+            return mm_builder_utils.get_image_embedding(
+                img, model=self.clip_model, processor=self.clip_processor
+            )
         except Exception as e:  # pragma: no cover - heavy deps may be missing
             logger.error("画像埋め込み生成エラー: %s", e)
             return None
 
-    @staticmethod
-    def generate_text_embedding(text: str) -> Optional[list[float]]:
+    def generate_text_embedding(self, text: str) -> Optional[list[float]]:
         """Return an embedding vector for ``text`` using the default model."""
         try:
             from core import mm_builder_utils

--- a/knowledgeplus_design-main/tests/test_file_processor_embeddings.py
+++ b/knowledgeplus_design-main/tests/test_file_processor_embeddings.py
@@ -26,13 +26,14 @@ def _make_png():
 
 def test_process_image_saves_embedding(tmp_path, monkeypatch):
     monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
+    builder = KnowledgeBuilder(FileProcessor(), lambda: None, lambda *_: None)
     monkeypatch.setattr(
-        KnowledgeBuilder,
+        builder,
         "generate_image_embedding",
-        staticmethod(lambda b: [0.1, 0.2]),
+        lambda b: [0.1, 0.2],
     )
     buf = _make_png()
-    FileProcessor.process_file(buf, kb_name="kb1")
+    FileProcessor.process_file(buf, kb_name="kb1", builder=builder)
     emb_dir = tmp_path / "kb1" / "embeddings"
     files = list(emb_dir.glob("*.pkl"))
     assert len(files) == 1
@@ -46,14 +47,11 @@ def test_process_image_saves_embedding(tmp_path, monkeypatch):
 
 def test_process_document_saves_embedding(tmp_path, monkeypatch):
     monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
-    monkeypatch.setattr(
-        KnowledgeBuilder,
-        "generate_text_embedding",
-        staticmethod(lambda t: [0.5]),
-    )
+    builder = KnowledgeBuilder(FileProcessor(), lambda: None, lambda *_: None)
+    monkeypatch.setattr(builder, "generate_text_embedding", lambda t: [0.5])
     buf = io.BytesIO(b"hello world")
     buf.name = "note.txt"
-    FileProcessor.process_file(buf, kb_name="kb2")
+    FileProcessor.process_file(buf, kb_name="kb2", builder=builder)
     emb_dir = tmp_path / "kb2" / "embeddings"
     files = list(emb_dir.glob("*.pkl"))
     assert len(files) == 1

--- a/knowledgeplus_design-main/tests/test_process_file_docs.py
+++ b/knowledgeplus_design-main/tests/test_process_file_docs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
 
 from shared.file_processor import FileProcessor  # noqa: E402
+from shared.kb_builder import KnowledgeBuilder  # noqa: E402
 
 
 def _create_text_pdf():
@@ -60,7 +61,8 @@ def _create_image_docx(tmp_path):
 
 def test_process_file_text_pdf():
     buf = _create_text_pdf()
-    result = FileProcessor.process_file(buf)
+    builder = KnowledgeBuilder(FileProcessor(), lambda: None, lambda *_: None)
+    result = FileProcessor.process_file(buf, builder=builder)
     assert result["type"] == "document"
     assert "hello pdf" in result["text"]
     assert result["images"]
@@ -68,7 +70,8 @@ def test_process_file_text_pdf():
 
 def test_process_file_image_pdf(tmp_path):
     buf = _create_image_pdf(tmp_path)
-    result = FileProcessor.process_file(buf)
+    builder = KnowledgeBuilder(FileProcessor(), lambda: None, lambda *_: None)
+    result = FileProcessor.process_file(buf, builder=builder)
     assert result["type"] == "image"
     assert result["metadata"]["file_type"] == "image_file"
     assert result["image_base64"]
@@ -77,7 +80,8 @@ def test_process_file_image_pdf(tmp_path):
 def test_process_file_text_docx(tmp_path):
     path = _create_text_docx(tmp_path)
     with open(path, "rb") as f:
-        result = FileProcessor.process_file(f)
+        builder = KnowledgeBuilder(FileProcessor(), lambda: None, lambda *_: None)
+        result = FileProcessor.process_file(f, builder=builder)
     assert result["type"] == "document"
     assert "hello docx" in result["text"]
 
@@ -85,7 +89,8 @@ def test_process_file_text_docx(tmp_path):
 def test_process_file_image_docx(tmp_path):
     path = _create_image_docx(tmp_path)
     with open(path, "rb") as f:
-        result = FileProcessor.process_file(f)
+        builder = KnowledgeBuilder(FileProcessor(), lambda: None, lambda *_: None)
+        result = FileProcessor.process_file(f, builder=builder)
     assert result["type"] == "image"
     assert result["metadata"]["file_type"] == "image_file"
     assert result["image_base64"]

--- a/knowledgeplus_design-main/ui_modules/management_ui.py
+++ b/knowledgeplus_design-main/ui_modules/management_ui.py
@@ -67,7 +67,8 @@ def render_management_mode():
                         try:
                             with st.spinner(progress_text):
                                 processed_data = file_processor.process_file(
-                                    uploaded_file
+                                    uploaded_file,
+                                    builder=kb_builder,
                                 )
                                 proc_type = processed_data.get("type")
                                 image_b64 = processed_data.get("image_base64")


### PR DESCRIPTION
## Summary
- initialize CLIP model and processor in `KnowledgeBuilder.__init__`
- use the cached model in `generate_image_embedding`
- update `file_processor.process_file` to accept a `KnowledgeBuilder`
- adjust `mm_kb_builder.app` and `management_ui` to pass the builder
- update tests for the new interface
- move default `KnowledgeBuilder` creation in `mm_builder_utils`

## Testing
- `pytest knowledgeplus_design-main/tests/test_file_processor_embeddings.py::test_process_image_saves_embedding -q`
- `pytest knowledgeplus_design-main/tests/test_process_file_docs.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68778a065e5c8333949c8b74a5b24c79