### PR TITLE
Update tests for CLIP embeddings

### DIFF
--- a/knowledgeplus_design-main/tests/test_file_processor_embeddings.py
+++ b/knowledgeplus_design-main/tests/test_file_processor_embeddings.py
@@ -50,7 +50,9 @@ def test_process_image_saves_embedding(tmp_path, monkeypatch):
 def test_process_document_saves_embedding(tmp_path, monkeypatch):
     monkeypatch.setattr(upload_utils, "BASE_KNOWLEDGE_DIR", tmp_path)
     builder = KnowledgeBuilder(FileProcessor(), lambda: None, lambda *_: None)
-    monkeypatch.setattr(builder, "generate_text_embedding", lambda t: [0.5] * EMBEDDING_DIM)
+    monkeypatch.setattr(
+        builder, "generate_text_embedding", lambda t: [0.5] * EMBEDDING_DIM
+    )
     buf = io.BytesIO(b"hello world")
     buf.name = "note.txt"
     FileProcessor.process_file(buf, kb_name="kb2", builder=builder)

--- a/knowledgeplus_design-main/tests/test_kb_builder.py
+++ b/knowledgeplus_design-main/tests/test_kb_builder.py
@@ -10,6 +10,7 @@ import pytest
 
 sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
 
+from config import EMBEDDING_DIM  # noqa: E402
 from shared.file_processor import FileProcessor  # noqa: E402
 from shared.kb_builder import KnowledgeBuilder  # noqa: E402
 
@@ -35,7 +36,7 @@ def mock_openai_client():
         inputs = kwargs.get("input")
         if not isinstance(inputs, list):
             inputs = [inputs]
-        return MockEmbeddingsResponse([[0.1] * 1536 for _ in inputs])
+        return MockEmbeddingsResponse([[0.1] * EMBEDDING_DIM for _ in inputs])
 
     client.embeddings.create.side_effect = create
     client.chat.completions.create.return_value = MagicMock(

--- a/knowledgeplus_design-main/tests/test_management_embeddings_and_index.py
+++ b/knowledgeplus_design-main/tests/test_management_embeddings_and_index.py
@@ -20,6 +20,7 @@ sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
 
 pytest.importorskip("streamlit")
 import streamlit as st  # noqa: E402
+from config import EMBEDDING_DIM  # noqa: E402
 from core import mm_builder_utils  # noqa: E402
 from shared import upload_utils  # noqa: E402
 from shared.search_engine import HybridSearchEngine  # noqa: E402
@@ -75,12 +76,12 @@ def test_render_management_mode_embeddings_and_index(tmp_path, monkeypatch):
     monkeypatch.setattr(
         mm_builder_utils,
         "get_text_embedding",
-        lambda text, model=None, processor=None: [0.1],
+        lambda text, model=None, processor=None: [0.1] * EMBEDDING_DIM,
     )
     monkeypatch.setattr(
         mm_builder_utils,
         "get_image_embedding",
-        lambda img, model=None, processor=None: [0.2],
+        lambda img, model=None, processor=None: [0.2] * EMBEDDING_DIM,
     )
     monkeypatch.setattr(
         mm_builder_utils, "load_model_and_processor", lambda: (object(), object())

--- a/knowledgeplus_design-main/tests/test_management_integration.py
+++ b/knowledgeplus_design-main/tests/test_management_integration.py
@@ -37,8 +37,9 @@ def test_render_management_mode_mixed_files(monkeypatch):
     monkeypatch.setattr(st, "number_input", lambda *a, **k: 1)
     monkeypatch.setattr(st, "spinner", lambda *a, **k: dummy_ctx)
     errors = []
+    successes = []
     monkeypatch.setattr(st, "error", lambda msg, *a, **k: errors.append(msg))
-    monkeypatch.setattr(st, "success", lambda *a, **k: None)
+    monkeypatch.setattr(st, "success", lambda msg, *a, **k: successes.append(msg))
     monkeypatch.setattr(st, "toast", lambda *a, **k: None)
 
     class DummyProgress:
@@ -109,3 +110,5 @@ def test_render_management_mode_mixed_files(monkeypatch):
     assert builder.calls == ["pic.png"]
     assert analysis_calls == ["pic.png"]
     assert not errors
+    assert "✓ ドキュメントを追加しました: doc.txt" in successes
+    assert "✓ ナレッジを追加しました: pic.png" in successes

--- a/knowledgeplus_design-main/tests/test_sample_png_upload.py
+++ b/knowledgeplus_design-main/tests/test_sample_png_upload.py
@@ -33,7 +33,7 @@ def mock_openai_client():
         inputs = kwargs.get("input")
         if not isinstance(inputs, list):
             inputs = [inputs]
-        return MockEmbeddingsResponse([[0.1] * 1536 for _ in inputs])
+        return MockEmbeddingsResponse([[0.1] * EMBEDDING_DIM for _ in inputs])
 
     client.embeddings.create.side_effect = create
     client.chat.completions.create.return_value = MagicMock(


### PR DESCRIPTION
## Summary
- adjust unit tests for CLIP embedding size
- capture management UI success messages and verify image vs document flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687898cf8a9083338a2380667da7ae73