### PR TITLE
Fix chat UI KB search

### DIFF
--- a/knowledgeplus_design-main/ui_modules/chat_ui.py
+++ b/knowledgeplus_design-main/ui_modules/chat_ui.py
@@ -15,6 +15,8 @@ def render_chat_mode(safe_generate_gpt_response):
     # Display current conversation title underneath the header
     st.markdown(f"### {st.session_state.get('gpt_conversation_title', '新しい会話')}")
     use_kb = st.session_state.get("use_knowledge_search", True)
+    if st.session_state.get("current_mode") == "チャット":
+        use_kb = False
 
     # Use configured search weights without showing the slider
     vec_weight = HYBRID_VECTOR_WEIGHT


### PR DESCRIPTION
## Summary
- disable knowledge base search when in chat mode

## Testing
- `pre-commit run --files knowledgeplus_design-main/ui_modules/chat_ui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a6d2c727483338512f64eb27f461f