### PR TITLE
Improve chat input styling

### DIFF
--- a/knowledgeplus_design-main/ui_modules/static/theme.css
+++ b/knowledgeplus_design-main/ui_modules/static/theme.css
@@ -474,14 +474,19 @@ button#toggle_sidebar p {
 
     /* Chat input styling - improved visibility */
     .st-chat-input {
-        border: 1px solid #dadce0; /* Add a clear border */
+        border: 1px solid #888888; /* More visible border */
         border-radius: 8px;
         padding: 8px;
         background-color: #f8f9fa; /* Slightly different background */
     }
-    .st-chat-input input {
+    .st-chat-input input,
+    .st-chat-input textarea {
         border: none; /* Remove inner input border */
         box-shadow: none; /* Remove inner input shadow */
+        min-height: 2.75em; /* Allow multi-line input */
+        resize: vertical; /* Let users expand the field */
+        overflow-y: auto;
+        white-space: pre-wrap; /* Wrap long text */
     }
 
     /* Chat message styling */


### PR DESCRIPTION
## Summary
- adjust chat input border to gray for better visibility
- allow multi-line chat messages with resizing

## Testing
- `pre-commit run --files knowledgeplus_design-main/ui_modules/static/theme.css`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*

------
https://chatgpt.com/codex/tasks/task_e_687ade5e0c088333a40cd55be9a6cbe0