### PR TITLE
Add experiment manager module

### DIFF
--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -127,6 +127,14 @@ graph TD
 *   **ChatController**: 会話履歴を管理し、`HybridSearchEngine` から取得したコンテキストを基にGPTモデル（OpenAI API）を呼び出し、ユーザーの質問に対する応答を生成します。
 *   **app.py**: Streamlitを用いたユーザーインターフェースを提供し、上記のバックエンドコンポーネントを統合して、シームレスなユーザー体験を実現します。
 
+## 🔬 Experiment Manager
+
+`shared/experiment_manager.py` では検索アルゴリズムごとの利用状況を記録できます。
+`record_result()` で成功数を蓄積し、十分な試行が溜まったら `deploy_best()` を
+実行して最も成績の良いアルゴリズム名を `data/active_algorithm.txt` に書き込みます。
+次回起動時は `get_active_algorithm()` でこの値を読み込み、自動的に最適な検索エ
+ンジンを選択できます。
+
 ## 🧪 テストの実行
 
 自動テストスイートは `pytest` で実行できます。

--- a/knowledgeplus_design-main/shared/experiment_manager.py
+++ b/knowledgeplus_design-main/shared/experiment_manager.py
@@ -1,0 +1,79 @@
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+_DEFAULT_METRICS = (
+    Path(__file__).resolve().parents[1] / "data" / "experiment_metrics.json"
+)
+_DEFAULT_DEPLOY = Path(__file__).resolve().parents[1] / "data" / "active_algorithm.txt"
+
+logger = logging.getLogger(__name__)
+
+
+class ExperimentManager:
+    """Track algorithm performance and deploy the best one."""
+
+    def __init__(
+        self,
+        metrics_path: Path = _DEFAULT_METRICS,
+        deploy_path: Path = _DEFAULT_DEPLOY,
+    ) -> None:
+        self.metrics_path = metrics_path
+        self.deploy_path = deploy_path
+        self.metrics = self._load_metrics()
+
+    def _load_metrics(self) -> Dict[str, Dict[str, int]]:
+        if self.metrics_path.exists():
+            try:
+                with open(self.metrics_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    return {
+                        k: {
+                            "runs": int(v.get("runs", 0)),
+                            "success": int(v.get("success", 0)),
+                        }
+                        for k, v in data.items()
+                    }
+            except Exception as e:  # pragma: no cover - log only
+                logger.warning("Failed to load metrics: %s", e)
+        return {}
+
+    def _save_metrics(self) -> None:
+        self.metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.metrics_path, "w", encoding="utf-8") as f:
+            json.dump(self.metrics, f, ensure_ascii=False, indent=2)
+
+    def record_result(self, algorithm: str, success: bool) -> None:
+        stats = self.metrics.setdefault(algorithm, {"runs": 0, "success": 0})
+        stats["runs"] += 1
+        if success:
+            stats["success"] += 1
+        self._save_metrics()
+
+    def select_best(self, min_runs: int = 5) -> Optional[str]:
+        best = None
+        best_rate = -1.0
+        for alg, stats in self.metrics.items():
+            if stats["runs"] < min_runs:
+                continue
+            rate = stats["success"] / stats["runs"] if stats["runs"] else 0.0
+            if rate > best_rate:
+                best_rate = rate
+                best = alg
+        return best
+
+    def deploy_best(self, min_runs: int = 5) -> Optional[str]:
+        alg = self.select_best(min_runs)
+        if alg:
+            self.deploy_path.parent.mkdir(parents=True, exist_ok=True)
+            self.deploy_path.write_text(alg, encoding="utf-8")
+        return alg
+
+    def get_active_algorithm(self, fallback: str) -> str:
+        if self.deploy_path.exists():
+            alg = self.deploy_path.read_text(encoding="utf-8").strip()
+            if alg:
+                return alg
+        return fallback

--- a/knowledgeplus_design-main/tests/test_experiment_manager.py
+++ b/knowledgeplus_design-main/tests/test_experiment_manager.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from shared.experiment_manager import ExperimentManager
+
+
+def test_record_and_deploy(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.json"
+    deploy = tmp_path / "deploy.txt"
+    mgr = ExperimentManager(metrics, deploy)
+
+    for _ in range(10):
+        mgr.record_result("algo_a", True)
+    for _ in range(10):
+        mgr.record_result("algo_b", False)
+
+    best = mgr.deploy_best(min_runs=5)
+    assert best == "algo_a"
+    assert deploy.read_text(encoding="utf-8") == "algo_a"
+    assert mgr.get_active_algorithm("default") == "algo_a"


### PR DESCRIPTION
## Summary
- implement `ExperimentManager` for tracking search algorithm metrics and deployment
- expose new logic with a basic unit test
- document how to use the experiment manager

## Testing
- `scripts/install_tests.sh`
- `scripts/install_light.sh`
- `pre-commit run --files knowledgeplus_design-main/shared/experiment_manager.py knowledgeplus_design-main/tests/test_experiment_manager.py knowledgeplus_design-main/README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b21d023108333aed5a0ad2a3a0492