### PR TITLE
Update test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,22 +144,16 @@ pre-commit install
 
 ## Testing
 
-Before running `pytest`, install the minimal dependencies required for the test
-suite. The helper script below pulls in packages such as **Pillow**, which the
-tests rely on:
-```bash
-scripts/install_light.sh
-```
-
-If you only want to run the tests without setting up the full application,
-use the optional script below. It installs `numpy`, `PyMuPDF` and other
-libraries required by the test suite:
+Before running `pytest`, install the libraries required by the test suite. The
+quickest way is to run the dedicated helper script:
 
 ```bash
 scripts/install_tests.sh
 ```
 
-If certain tests depend on heavier libraries, you can also run:
+This installs `numpy`, `PyMuPDF`, **Pillow** and other dependencies the tests
+expect. If some tests need heavier packages (for example those that rely on
+`torch` or `transformers`), install them with:
 
 ```bash
 scripts/install_extra.sh

--- a/knowledgeplus_design-main/README.md
+++ b/knowledgeplus_design-main/README.md
@@ -137,11 +137,13 @@ graph TD
 
 ## 🧪 テストの実行
 
-自動テストスイートは `pytest` で実行できます。
-`numpy` や `PyMuPDF` などテストに必要なライブラリは、リポジトリ直下の
-`scripts/install_tests.sh` でまとめてインストールできます。
+自動テストスイートは `pytest` で実行できます。まず `scripts/install_tests.sh` を
+実行して `numpy` や `PyMuPDF` など必須ライブラリを導入してください。必要に応じて
+`scripts/install_extra.sh` で heavy な依存関係も追加します。
 
 ```bash
+scripts/install_tests.sh
+scripts/install_extra.sh  # テスト内容に応じて
 pytest -q
 ```
 PNG アップロード処理を検証するテストでは、コード内で小さな画像を生成して


### PR DESCRIPTION
## Summary
- document `scripts/install_tests.sh` as the first step before running tests
- mention that `scripts/install_extra.sh` installs heavy optional dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_687b37aff86c8333b8f4d587c2181484