### PR TITLE
Add search metrics collector

### DIFF
--- a/knowledgeplus_design-main/shared/metrics.py
+++ b/knowledgeplus_design-main/shared/metrics.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import List
+
+
+class SearchMetricsCollector:
+    """Collect and report search metrics."""
+
+    def __init__(self) -> None:
+        self.metrics = {
+            "total_searches": 0,
+            "version_filtered": 0,
+            "conflict_detected": 0,
+            "avg_response_time": 0,
+            "cache_hit_rate": 0,
+        }
+
+    def log_search(
+        self, query: str, results: List[dict], execution_time: float, cache_hit: bool = False
+    ) -> None:
+        """Record a search execution."""
+        self.metrics["total_searches"] += 1
+
+        version_filtered = sum(
+            1
+            for r in results
+            if r.get("metadata", {}).get("version_info", {}).get("status") == "active"
+        )
+        self.metrics["version_filtered"] += version_filtered / max(len(results), 1)
+
+        conflicts_found = sum(1 for r in results if r.get("conflicts"))
+        if conflicts_found > 0:
+            self.metrics["conflict_detected"] += 1
+
+        n = self.metrics["total_searches"]
+        self.metrics["avg_response_time"] = (
+            (self.metrics["avg_response_time"] * (n - 1) + execution_time) / n
+        )
+
+        if cache_hit:
+            self.metrics["cache_hit_rate"] = (
+                (self.metrics["cache_hit_rate"] * (n - 1) + 1) / n
+            )
+        else:
+            self.metrics["cache_hit_rate"] = (
+                (self.metrics["cache_hit_rate"] * (n - 1)) / n
+            )
+
+    def get_report(self) -> dict:
+        """Return a metrics summary with improvement tips."""
+        conflict_rate = self.metrics["conflict_detected"] / max(
+            self.metrics["total_searches"], 1
+        )
+        self.metrics["conflict_rate"] = conflict_rate
+        return {
+            **self.metrics,
+            "recommendations": self._generate_recommendations(),
+        }
+
+    def _generate_recommendations(self) -> List[str]:
+        """Generate improvement suggestions from metrics."""
+        recommendations: List[str] = []
+
+        if self.metrics["avg_response_time"] > 2.0:
+            recommendations.append(
+                "検索速度が遅いです。インデックスの再構築を検討してください。"
+            )
+
+        if self.metrics.get("conflict_rate", 0) > 0.3:
+            recommendations.append(
+                "ルール矛盾が多く検出されています。文書の標準化を推進してください。"
+            )
+
+        if self.metrics["cache_hit_rate"] < 0.2:
+            recommendations.append(
+                "キャッシュヒット率が低いです。キャッシュサイズの拡大を検討してください。"
+            )
+
+        return recommendations
+
+
+# default collector used by the search engine
+collector = SearchMetricsCollector()
+
+
+def get_collector() -> SearchMetricsCollector:
+    """Return the global metrics collector."""
+    return collector
+
+
+def get_report() -> dict:
+    """Return metrics report from the global collector."""
+    return collector.get_report()

--- a/knowledgeplus_design-main/shared/metrics.py
+++ b/knowledgeplus_design-main/shared/metrics.py
@@ -16,7 +16,11 @@ class SearchMetricsCollector:
         }
 
     def log_search(
-        self, query: str, results: List[dict], execution_time: float, cache_hit: bool = False
+        self,
+        query: str,
+        results: List[dict],
+        execution_time: float,
+        cache_hit: bool = False,
     ) -> None:
         """Record a search execution."""
         self.metrics["total_searches"] += 1
@@ -34,17 +38,17 @@ class SearchMetricsCollector:
 
         n = self.metrics["total_searches"]
         self.metrics["avg_response_time"] = (
-            (self.metrics["avg_response_time"] * (n - 1) + execution_time) / n
-        )
+            self.metrics["avg_response_time"] * (n - 1) + execution_time
+        ) / n
 
         if cache_hit:
             self.metrics["cache_hit_rate"] = (
-                (self.metrics["cache_hit_rate"] * (n - 1) + 1) / n
-            )
+                self.metrics["cache_hit_rate"] * (n - 1) + 1
+            ) / n
         else:
             self.metrics["cache_hit_rate"] = (
-                (self.metrics["cache_hit_rate"] * (n - 1)) / n
-            )
+                self.metrics["cache_hit_rate"] * (n - 1)
+            ) / n
 
     def get_report(self) -> dict:
         """Return a metrics summary with improvement tips."""
@@ -62,19 +66,13 @@ class SearchMetricsCollector:
         recommendations: List[str] = []
 
         if self.metrics["avg_response_time"] > 2.0:
-            recommendations.append(
-                "検索速度が遅いです。インデックスの再構築を検討してください。"
-            )
+            recommendations.append("検索速度が遅いです。インデックスの再構築を検討してください。")
 
         if self.metrics.get("conflict_rate", 0) > 0.3:
-            recommendations.append(
-                "ルール矛盾が多く検出されています。文書の標準化を推進してください。"
-            )
+            recommendations.append("ルール矛盾が多く検出されています。文書の標準化を推進してください。")
 
         if self.metrics["cache_hit_rate"] < 0.2:
-            recommendations.append(
-                "キャッシュヒット率が低いです。キャッシュサイズの拡大を検討してください。"
-            )
+            recommendations.append("キャッシュヒット率が低いです。キャッシュサイズの拡大を検討してください。")
 
         return recommendations
 

--- a/knowledgeplus_design-main/shared/search_engine.py
+++ b/knowledgeplus_design-main/shared/search_engine.py
@@ -26,6 +26,7 @@ except Exception as e:
     logging.warning(f"SentenceTransformer import failed: {e}")
 import logging
 import re
+import time
 import typing
 from pathlib import Path
 
@@ -37,11 +38,10 @@ from nltk.corpus import stopwords
 # import time # 直接は不要
 from rank_bm25 import BM25Okapi
 from shared.feedback_store import load_feedback
+from shared.metrics import get_collector
 from shared.nltk_utils import ensure_nltk_resources
 from shared.openai_utils import get_embeddings_batch, get_openai_client
 from shared.thesaurus import expand_query, load_synonyms
-from shared.metrics import get_collector
-import time
 
 logger = logging.getLogger(__name__)
 

--- a/knowledgeplus_design-main/shared/search_engine.py
+++ b/knowledgeplus_design-main/shared/search_engine.py
@@ -40,6 +40,8 @@ from shared.feedback_store import load_feedback
 from shared.nltk_utils import ensure_nltk_resources
 from shared.openai_utils import get_embeddings_batch, get_openai_client
 from shared.thesaurus import expand_query, load_synonyms
+from shared.metrics import get_collector
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -1121,6 +1123,8 @@ class EnhancedHybridSearchEngine(HybridSearchEngine):
         bm25_weight: typing.Optional[float] = None,
         client=None,
     ) -> tuple[list[dict], bool]:
+        collector = get_collector()
+        start_time = time.monotonic()
         logger.info(f"拡張検索開始: query='{query}'")
         processed_query = expand_query(query, self.synonyms)
         intent = self.classify_query_intent(processed_query, client)
@@ -1223,6 +1227,8 @@ class EnhancedHybridSearchEngine(HybridSearchEngine):
                     ]
 
         logger.info(f"拡張検索完了: {len(final_results)}件の結果")
+        execution_time = time.monotonic() - start_time
+        collector.log_search(query, final_results, execution_time, cache_hit=False)
         return final_results, len(final_results) == 0
 
 

--- a/knowledgeplus_design-main/tests/test_metrics.py
+++ b/knowledgeplus_design-main/tests/test_metrics.py
@@ -1,12 +1,14 @@
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
 
-from shared.metrics import SearchMetricsCollector, get_collector, get_report
-from shared.search_engine import EnhancedHybridSearchEngine, HybridSearchEngine
+import pytest  # noqa: E402
+from shared.metrics import SearchMetricsCollector  # noqa: E402
+from shared.search_engine import (  # noqa: E402
+    EnhancedHybridSearchEngine,
+    HybridSearchEngine,
+)
 
 
 def test_metrics_collector_updates_and_report():

--- a/knowledgeplus_design-main/tests/test_metrics.py
+++ b/knowledgeplus_design-main/tests/test_metrics.py
@@ -1,0 +1,83 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+
+from shared.metrics import SearchMetricsCollector, get_collector, get_report
+from shared.search_engine import EnhancedHybridSearchEngine, HybridSearchEngine
+
+
+def test_metrics_collector_updates_and_report():
+    collector = SearchMetricsCollector()
+    collector.log_search(
+        "q1",
+        [{"metadata": {"version_info": {"status": "active"}}}],
+        1.0,
+        cache_hit=True,
+    )
+    collector.log_search(
+        "q2",
+        [
+            {"metadata": {}},
+            {
+                "metadata": {"version_info": {"status": "active"}},
+                "conflicts": ["x"],
+            },
+        ],
+        3.0,
+        cache_hit=False,
+    )
+    report = collector.get_report()
+    assert report["total_searches"] == 2
+    assert abs(report["version_filtered"] - 1.5) < 1e-6
+    assert report["conflict_detected"] == 1
+    assert abs(report["avg_response_time"] - 2.0) < 1e-6
+    assert abs(report["cache_hit_rate"] - 0.5) < 1e-6
+    assert abs(report["conflict_rate"] - 0.5) < 1e-6
+    assert any("ルール矛盾" in rec for rec in report["recommendations"])
+
+
+@pytest.fixture
+def empty_kb(tmp_path):
+    kb_path = tmp_path / "kb"
+    (kb_path / "chunks").mkdir(parents=True)
+    (kb_path / "metadata").mkdir()
+    (kb_path / "embeddings").mkdir()
+    (kb_path / "kb_metadata.json").write_text("{}", encoding="utf-8")
+    return kb_path
+
+
+def test_enhanced_search_engine_logs_metrics(monkeypatch, empty_kb):
+    collector = SearchMetricsCollector()
+    import shared.metrics as metrics_module
+
+    monkeypatch.setattr(metrics_module, "collector", collector, raising=False)
+    monkeypatch.setattr(metrics_module, "get_collector", lambda: collector)
+
+    engine = EnhancedHybridSearchEngine(str(empty_kb))
+
+    monkeypatch.setattr(engine, "classify_query_intent", lambda q, client=None: {})
+    monkeypatch.setattr(
+        HybridSearchEngine,
+        "search",
+        lambda self, query, **kwargs: (
+            [
+                {
+                    "id": "c1",
+                    "text": "x",
+                    "metadata": {"version_info": {"status": "active"}},
+                    "similarity": 0.5,
+                }
+            ],
+            False,
+        ),
+    )
+    monkeypatch.setattr(engine, "detect_rule_conflicts", lambda chunks, client=None: [])
+
+    engine.search("query")
+
+    report = collector.get_report()
+    assert report["total_searches"] == 1
+    assert report["version_filtered"] > 0


### PR DESCRIPTION
## Summary
- implement `SearchMetricsCollector` to gather search quality metrics
- log metrics from `EnhancedHybridSearchEngine.search`
- expose `get_report` and unit tests for metrics

## Testing
- `pytest -q knowledgeplus_design-main/tests/test_metrics.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_687b4f6c89e08333b5c5f7cf76b7fc0f