### PR TITLE
Add caching to search engine

### DIFF
--- a/knowledgeplus_design-main/tests/test_cached_search_engine.py
+++ b/knowledgeplus_design-main/tests/test_cached_search_engine.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+
+import pytest  # noqa: E402
+from shared.search_engine import (  # noqa: E402
+    CachedEnhancedSearchEngine,
+    EnhancedHybridSearchEngine,
+    HybridSearchEngine,
+)
+
+
+@pytest.fixture
+def empty_kb(tmp_path):
+    kb_path = tmp_path / "kb"
+    (kb_path / "chunks").mkdir(parents=True)
+    (kb_path / "metadata").mkdir()
+    (kb_path / "embeddings").mkdir()
+    (kb_path / "kb_metadata.json").write_text("{}", encoding="utf-8")
+    return kb_path
+
+
+def test_classify_query_intent_cached(monkeypatch, empty_kb):
+    engine = CachedEnhancedSearchEngine(str(empty_kb))
+
+    calls = {"count": 0}
+
+    def fake_parent(self, query, client=None):
+        calls["count"] += 1
+        return {"primary_intent": "general"}
+
+    monkeypatch.setattr(
+        EnhancedHybridSearchEngine,
+        "classify_query_intent",
+        fake_parent,
+        raising=False,
+    )
+
+    assert engine.classify_query_intent("hello") == {"primary_intent": "general"}
+    assert engine.classify_query_intent("hello") == {"primary_intent": "general"}
+    assert calls["count"] == 1
+
+
+def test_search_uses_intent_cache(monkeypatch, empty_kb):
+    engine = CachedEnhancedSearchEngine(str(empty_kb))
+
+    calls = {"count": 0}
+
+    def fake_parent(self, query, client=None):
+        calls["count"] += 1
+        return {}
+
+    monkeypatch.setattr(
+        EnhancedHybridSearchEngine,
+        "classify_query_intent",
+        fake_parent,
+        raising=False,
+    )
+    monkeypatch.setattr(HybridSearchEngine, "search", lambda *a, **k: ([], True))
+
+    engine.search("foo")
+    engine.search("foo")
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- implement `CachedEnhancedSearchEngine` with LRU cache
- allow enabling the cache via `USE_CACHED_ENGINE` in the app
- pick cached or normal engine in `get_search_engine`
- add unit tests for cached intent analysis

## Testing
- `pre-commit run --files knowledgeplus_design-main/shared/search_engine.py knowledgeplus_design-main/knowledge_gpt_app/app.py knowledgeplus_design-main/tests/test_cached_search_engine.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b99bb2ef08333baf1de06091d4441