### PR TITLE
Add synonym editing interface

### DIFF
--- a/knowledgeplus_design-main/shared/thesaurus.py
+++ b/knowledgeplus_design-main/shared/thesaurus.py
@@ -26,3 +26,20 @@ def expand_query(query: str, synonyms: Dict[str, List[str]]) -> str:
         if t in synonyms:
             expanded.extend(synonyms[t])
     return " ".join(expanded)
+
+
+def save_synonyms(data: Dict[str, List[str]], path: Path | None = None) -> None:
+    """Write a synonyms dictionary to disk."""
+    p = Path(path) if path else _DEFAULT_PATH
+    with open(p, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def update_synonyms(
+    term: str, words: List[str], path: Path | None = None
+) -> Dict[str, List[str]]:
+    """Add or update a term's synonyms and persist them."""
+    syns = load_synonyms(path)
+    syns[str(term)] = list(words)
+    save_synonyms(syns, path)
+    return syns

--- a/knowledgeplus_design-main/tests/test_thesaurus.py
+++ b/knowledgeplus_design-main/tests/test_thesaurus.py
@@ -1,0 +1,16 @@
+import json
+
+from shared.thesaurus import load_synonyms, update_synonyms
+
+
+def test_load_synonyms_missing(tmp_path):
+    path = tmp_path / "syn.json"
+    assert load_synonyms(path) == {}
+
+
+def test_update_synonyms_creates_and_loads(tmp_path):
+    path = tmp_path / "syn.json"
+    updated = update_synonyms("foo", ["bar", "baz"], path)
+    assert updated == {"foo": ["bar", "baz"]}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data == updated


### PR DESCRIPTION
## Summary
- support saving synonyms in shared.thesaurus
- expose new tab in management UI for editing synonyms
- keep search engine synonyms refreshed after updates
- test thesaurus helpers

## Testing
- `pre-commit run --files knowledgeplus_design-main/shared/thesaurus.py knowledgeplus_design-main/ui_modules/management_ui.py knowledgeplus_design-main/tests/test_thesaurus.py`
- `pytest knowledgeplus_design-main/tests/test_thesaurus.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687c3c16bcb08333b1d9d870edea221f