### PR TITLE
Add zero-hit query logging feature

### DIFF
--- a/knowledgeplus_design-main/shared/zero_hit_logger.py
+++ b/knowledgeplus_design-main/shared/zero_hit_logger.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from typing import List
+
+_ZERO_HIT_PATH = Path(__file__).resolve().parents[1] / "data" / "zero_hit_queries.log"
+
+
+def log_zero_hit_query(query: str, path: Path | None = None) -> None:
+    """Append a search query to the zero-hit log."""
+    if not query:
+        return
+    p = Path(path) if path else _ZERO_HIT_PATH
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "a", encoding="utf-8") as f:
+        f.write(query.strip() + "\n")
+
+
+def load_zero_hit_queries(path: Path | None = None) -> List[str]:
+    """Return the list of recorded zero-hit queries."""
+    p = Path(path) if path else _ZERO_HIT_PATH
+    if not p.exists():
+        return []
+    with open(p, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]

--- a/knowledgeplus_design-main/tests/stubs/nltk/__init__.py
+++ b/knowledgeplus_design-main/tests/stubs/nltk/__init__.py
@@ -1,0 +1,3 @@
+from types import SimpleNamespace
+
+corpus = SimpleNamespace(stopwords=SimpleNamespace(words=lambda lang=None: []))

--- a/knowledgeplus_design-main/tests/stubs/nltk/corpus/__init__.py
+++ b/knowledgeplus_design-main/tests/stubs/nltk/corpus/__init__.py
@@ -1,2 +1,3 @@
 from . import stopwords
+
 __all__ = ["stopwords"]

--- a/knowledgeplus_design-main/tests/stubs/nltk/corpus/__init__.py
+++ b/knowledgeplus_design-main/tests/stubs/nltk/corpus/__init__.py
@@ -1,0 +1,2 @@
+from . import stopwords
+__all__ = ["stopwords"]

--- a/knowledgeplus_design-main/tests/stubs/nltk/corpus/stopwords.py
+++ b/knowledgeplus_design-main/tests/stubs/nltk/corpus/stopwords.py
@@ -1,0 +1,4 @@
+# Minimal stopwords stub
+
+def words(lang=None):
+    return []

--- a/knowledgeplus_design-main/tests/stubs/nltk/corpus/stopwords.py
+++ b/knowledgeplus_design-main/tests/stubs/nltk/corpus/stopwords.py
@@ -1,4 +1,5 @@
 # Minimal stopwords stub
 
+
 def words(lang=None):
     return []

--- a/knowledgeplus_design-main/tests/test_zero_hit_logger.py
+++ b/knowledgeplus_design-main/tests/test_zero_hit_logger.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import sys
 from pathlib import Path
 

--- a/knowledgeplus_design-main/tests/test_zero_hit_logger.py
+++ b/knowledgeplus_design-main/tests/test_zero_hit_logger.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(1, str(Path(__file__).resolve().parents[1]))
+
+from shared.zero_hit_logger import load_zero_hit_queries, log_zero_hit_query
+
+
+def test_log_and_load(tmp_path):
+    path = tmp_path / "zero.log"
+    log_zero_hit_query("foo", path)
+    log_zero_hit_query("bar", path)
+    assert load_zero_hit_queries(path) == ["foo", "bar"]
+
+
+def test_log_ignores_empty(tmp_path):
+    path = tmp_path / "zero.log"
+    log_zero_hit_query("", path)
+    assert load_zero_hit_queries(path) == []

--- a/knowledgeplus_design-main/ui_modules/management_ui.py
+++ b/knowledgeplus_design-main/ui_modules/management_ui.py
@@ -391,7 +391,7 @@ def render_management_mode():
             selected = st.selectbox("クエリを選択", unique)
             words = st.text_input("同義語 (カンマ区切り)", key="zero_syn_words")
             if st.button("同義語追加", key="zero_syn_save"):
-                new_words = [w.strip() for w in words.split(',') if w.strip()]
+                new_words = [w.strip() for w in words.split(",") if w.strip()]
                 update_synonyms(selected.strip(), new_words)
                 engine = get_search_engine(DEFAULT_KB_NAME)
                 if engine is not None:

--- a/knowledgeplus_design-main/ui_modules/management_ui.py
+++ b/knowledgeplus_design-main/ui_modules/management_ui.py
@@ -11,6 +11,7 @@ from shared.file_processor import FileProcessor
 from shared.kb_builder import KnowledgeBuilder
 from shared.openai_utils import get_openai_client
 from shared.thesaurus import load_synonyms, update_synonyms
+from shared.zero_hit_logger import load_zero_hit_queries
 from ui_modules.thumbnail_editor import display_thumbnail_grid
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 def render_management_mode():
     """Render the management interface including FAQ generation."""
     st.subheader("管理")
-    tabs = st.tabs(["ナレッジベース構築", "FAQ自動生成", "同義語管理"])
+    tabs = st.tabs(["ナレッジベース構築", "FAQ自動生成", "同義語管理", "ゼロヒットクエリ"])
 
     with tabs[0]:
         st.divider()
@@ -377,3 +378,24 @@ def render_management_mode():
             if engine is not None:
                 engine.synonyms = updated
             st.toast("同義語を更新しました")
+
+    with tabs[3]:
+        st.divider()
+        st.subheader("未ヒット検索クエリ")
+        queries = load_zero_hit_queries()
+        if queries:
+            unique = sorted(set(queries))
+            st.write("記録されたクエリ:")
+            for q in unique:
+                st.markdown(f"- {q}")
+            selected = st.selectbox("クエリを選択", unique)
+            words = st.text_input("同義語 (カンマ区切り)", key="zero_syn_words")
+            if st.button("同義語追加", key="zero_syn_save"):
+                new_words = [w.strip() for w in words.split(',') if w.strip()]
+                update_synonyms(selected.strip(), new_words)
+                engine = get_search_engine(DEFAULT_KB_NAME)
+                if engine is not None:
+                    engine.synonyms = load_synonyms()
+                st.toast("同義語を更新しました")
+        else:
+            st.info("記録されたゼロヒットクエリはありません。")

--- a/knowledgeplus_design-main/ui_modules/search_ui.py
+++ b/knowledgeplus_design-main/ui_modules/search_ui.py
@@ -3,6 +3,7 @@ from config import HYBRID_BM25_WEIGHT, HYBRID_VECTOR_WEIGHT
 from knowledge_gpt_app.app import list_knowledge_bases, search_multiple_knowledge_bases
 from shared import feedback_store
 from shared.openai_utils import get_openai_client
+from shared.zero_hit_logger import log_zero_hit_query
 from ui_modules.document_card import render_document_card
 
 
@@ -124,6 +125,8 @@ def render_search_mode(safe_generate_gpt_response):
                         == "company"
                     ]
                 st.session_state["results"] = results
+                if not results:
+                    log_zero_hit_query(query)
             else:
                 st.session_state["results"] = []
                 st.warning("検索可能なナレッジベースがありません。")


### PR DESCRIPTION
## Summary
- record search queries that return no results
- expose zero-hit queries in management UI for synonym updates
- include helper functions to log/load zero-hit queries
- add minimal nltk stubs and tests for zero-hit logger

## Testing
- `pytest -q knowledgeplus_design-main/tests/test_zero_hit_logger.py`
- `pytest -q` *(fails: missing heavy dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c7f39f828833383bb958c385f8d37