### PR TITLE
Update test requirements and installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,15 +145,16 @@ pre-commit install
 ## Testing
 
 Before running `pytest`, install the libraries required by the test suite. The
-quickest way is to run the dedicated helper script:
+quickest way is to run the dedicated helper script (the CI workflow calls this
+script as well):
 
 ```bash
 scripts/install_tests.sh
 ```
 
-This installs `numpy`, `PyMuPDF`, **Pillow** and other dependencies the tests
-expect. If some tests need heavier packages (for example those that rely on
-`torch` or `transformers`), install them with:
+This installs `numpy`, `requests`, `PyMuPDF`, **Pillow** and other dependencies
+the tests expect. If some tests need heavier packages (for example those that
+rely on `torch` or `transformers`), install them with:
 
 ```bash
 scripts/install_extra.sh

--- a/README_JA.md
+++ b/README_JA.md
@@ -58,8 +58,7 @@ GPT‑4.1 mini を使用し、温度は生成した質問数に応じて 0 か�
 ## テスト
 
 自動テストは `pytest -q` で実行できます。開発前に `scripts/install_light.sh` を実行して必要な依存パッケージを導入してください。
-テストのみを実行したい場合は、`numpy` や `PyMuPDF` など必須ライブラリだけを
-インストールする `scripts/install_tests.sh` も利用できます。
+テストのみを実行したい場合は、`numpy`、`requests`、`PyMuPDF` など必須ライブラリだけをインストールする `scripts/install_tests.sh` を使います。CI でもこのスクリプトを実行してから `pytest` を呼び出しています。
 
 ## 参考
 

--- a/knowledgeplus_design-main/requirements-tests.txt
+++ b/knowledgeplus_design-main/requirements-tests.txt
@@ -9,3 +9,5 @@ rank-bm25>=0.2.2
 nltk>=3.9.1
 streamlit>=1.28.0
 pytest>=8.1.1
+requests>=2.32.3
+

--- a/scripts/install_tests.sh
+++ b/scripts/install_tests.sh
@@ -2,4 +2,8 @@
 # Install dependencies required for running the test suite
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Install the lighter core packages first so the basic modules are available
+pip install -r "$REPO_ROOT/knowledgeplus_design-main/requirements-light.txt"
+# Then install the additional libraries needed only for tests
 pip install -r "$REPO_ROOT/knowledgeplus_design-main/requirements-tests.txt"


### PR DESCRIPTION
## Summary
- add missing `requests` to requirements-tests
- improve `install_tests.sh` to install light and test requirements
- clarify in docs that CI runs `install_tests.sh` before `pytest`

## Testing
- `pre-commit run --files scripts/install_tests.sh knowledgeplus_design-main/requirements-tests.txt README.md README_JA.md`
- `bash scripts/install_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cd6c840d88333b9160c796469e151