### PR TITLE
Add metrics reporting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,13 @@ The script fetches the URL, extracts text with Beautiful Soup and then calls
 GPT‑4.1 mini. Temperature starts at `0` and increases by `0.01` every five
 questions up to a maximum of `0.8`.
 
+
+## Metrics report
+
+Use `show_metrics.py` to display search performance metrics collected during the current session.
+
+```bash
+python show_metrics.py
+```
+
+The script prints a JSON summary including average response time and recommendations for improving search quality.

--- a/show_metrics.py
+++ b/show_metrics.py
@@ -5,8 +5,8 @@ from pathlib import Path
 # Ensure shared package is importable when running from repo root
 sys.path.insert(0, str(Path(__file__).resolve().parent / "knowledgeplus_design-main"))
 
-from shared.metrics import get_report  # noqa: E402
 from shared.logging_utils import configure_logging  # noqa: E402
+from shared.metrics import get_report  # noqa: E402
 
 
 def main() -> None:

--- a/show_metrics.py
+++ b/show_metrics.py
@@ -1,0 +1,20 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure shared package is importable when running from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parent / "knowledgeplus_design-main"))
+
+from shared.metrics import get_report  # noqa: E402
+from shared.logging_utils import configure_logging  # noqa: E402
+
+
+def main() -> None:
+    """Print search metrics as JSON."""
+    configure_logging()
+    report = get_report()
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `show_metrics.py` utility to print collected search metrics
- document usage in the README

## Testing
- `scripts/install_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce8bbc01c8333a237cf6b6bf56318