### PR TITLE
Fix safe_generate_gpt_response error propagation

### DIFF
--- a/knowledgeplus_design-main/tests/test_unified_app.py
+++ b/knowledgeplus_design-main/tests/test_unified_app.py
@@ -116,7 +116,6 @@ def test_safe_generate_handles_error(monkeypatch):
         lambda *a, **k: (
             types.SimpleNamespace(button=lambda *a, **k: False),
             types.SimpleNamespace(button=lambda *a, **k: False),
-            None,
         ),
     )
     sidebar = types.SimpleNamespace(radio=lambda *a, **k: "FAQ")
@@ -186,7 +185,6 @@ def test_safe_generate_missing_client(monkeypatch):
         lambda *a, **k: (
             types.SimpleNamespace(button=lambda *a, **k: False),
             types.SimpleNamespace(button=lambda *a, **k: False),
-            None,
         ),
     )
     sidebar = types.SimpleNamespace(radio=lambda *a, **k: "FAQ")

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -20,6 +20,7 @@ from ui_modules.management_ui import render_management_mode
 from ui_modules.search_ui import render_search_mode
 from ui_modules.sidebar_toggle import render_sidebar_toggle
 from ui_modules.theme import apply_intel_theme
+from shared.errors import OpenAIClientError
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,9 @@ def safe_generate_gpt_response(
             client=client,
         )
         return gen
+    except OpenAIClientError:
+        logger.error("GPT response generation error", exc_info=True)
+        raise
     except Exception as e:
         st.error(f"GPT応答生成エラー: {e}")
         logger.error("GPT response generation error", exc_info=True)


### PR DESCRIPTION
## Summary
- allow OpenAIClientError to surface from safe_generate_gpt_response
- match updated UI column count in unified_app tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da50c6e0c8333bedc1d915b9fddf6