### PR TITLE
Allow chat mode without a knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ You can override the default knowledge base name by setting
   export DEFAULT_KB_NAME=my_kb
   ```
 
+If the specified knowledge base does not exist, the chat interface will
+still launch and provide answers using only the OpenAI API. Search and
+FAQ generation features require a valid knowledge base, but plain GPT
+responses work without one.
+
 You can tune the default blend between vector similarity and keyword search by
 setting `HYBRID_VECTOR_WEIGHT` and `HYBRID_BM25_WEIGHT` before launching the
 app.  The values should sum to 1.0:

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -88,8 +88,12 @@ def safe_generate_gpt_response(
         if "chat_controller" not in st.session_state:
             engine = get_search_engine(DEFAULT_KB_NAME)
             if engine is None:
-                raise RuntimeError("Search engine initialization failed")
-            st.session_state.chat_controller = ChatController(engine)
+                logger.warning(
+                    "Search engine unavailable - continuing without knowledge base"
+                )
+                st.session_state.chat_controller = ChatController(None)  # type: ignore[arg-type]
+            else:
+                st.session_state.chat_controller = ChatController(engine)
 
         gen = st.session_state.chat_controller.generate_gpt_response(
             user_input,


### PR DESCRIPTION
## Summary
- fall back to a controller without a search engine when the KB is missing
- document that chat can run without a KB

## Testing
- `bash scripts/install_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e1a0ecc8c8333af6549fd70b28f32