### PR TITLE
Fix popover crash in management UI

### DIFF
--- a/knowledgeplus_design-main/ui_modules/management_ui.py
+++ b/knowledgeplus_design-main/ui_modules/management_ui.py
@@ -172,7 +172,7 @@ def render_management_mode():
                                     caption=item["filename"],
                                     use_container_width=True,
                                 )
-                            with st.popover("AI解析結果", key=f"analysis_{idx}"):
+                            with st.popover("AI解析結果"):
                                 st.json(item["analysis"])
 
                             title = st.text_input("タイトル", key=f"title_{idx}")


### PR DESCRIPTION
## Summary
- remove unsupported `key` argument from `st.popover`

## Testing
- `scripts/install_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e36e57a48833391ec21ccd5f9153e