### PR TITLE
Show user message before assistant reply

### DIFF
--- a/knowledgeplus_design-main/knowledge_gpt_app/app.py
+++ b/knowledgeplus_design-main/knowledge_gpt_app/app.py
@@ -2116,7 +2116,9 @@ elif app_mode == "chatGPT":
     )
 
     if user_chat_input_val:
-        # 1. ユーザーメッセージをセッションに追加
+        # ユーザーメッセージを即座に表示して履歴にも追加
+        with st.chat_message("user"):
+            st.markdown(user_chat_input_val)
         st.session_state.gpt_messages.append(
             {"role": "user", "content": user_chat_input_val}
         )


### PR DESCRIPTION
## Summary
- update chat flow so the user's message is rendered immediately in the chat interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4021aafc8333bc0228aa221663a6