### PR TITLE
Clear old search on navigation

### DIFF
--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -165,13 +165,21 @@ selected_mode_display = st.sidebar.radio(
 )
 # Convert the selected display label back to the internal key. If the label is
 # not recognized (e.g. in tests that monkeypatch the sidebar), keep the
-# existing mode to avoid errors.
+# existing mode to avoid errors. Track previous mode so search state can be
+# reset when switching to the search screen.
+previous_mode = st.session_state.get("current_mode")
 if selected_mode_display in mode_options.values():
-    st.session_state["current_mode"] = list(mode_options.keys())[
-        list(mode_options.values()).index(selected_mode_display)
-    ]
+    new_mode = list(mode_options.keys())[list(mode_options.values()).index(selected_mode_display)]
+    st.session_state["current_mode"] = new_mode
 else:
     logger.warning("Invalid mode selection: %s", selected_mode_display)
+    new_mode = previous_mode
+
+# Clear previous search results when navigating to the search screen
+if new_mode == "検索" and previous_mode != "検索":
+    st.session_state["search_executed"] = False
+    st.session_state["results"] = []
+    st.session_state["last_query"] = ""
 
 # Chat related sidebar controls. Some unit tests monkeypatch `st.sidebar` with a
 # simple object that only provides `radio()`. Guard these calls so the app can

--- a/knowledgeplus_design-main/unified_app.py
+++ b/knowledgeplus_design-main/unified_app.py
@@ -169,7 +169,9 @@ selected_mode_display = st.sidebar.radio(
 # reset when switching to the search screen.
 previous_mode = st.session_state.get("current_mode")
 if selected_mode_display in mode_options.values():
-    new_mode = list(mode_options.keys())[list(mode_options.values()).index(selected_mode_display)]
+    new_mode = list(mode_options.keys())[
+        list(mode_options.values()).index(selected_mode_display)
+    ]
     st.session_state["current_mode"] = new_mode
 else:
     logger.warning("Invalid mode selection: %s", selected_mode_display)


### PR DESCRIPTION
## Summary
- ensure previous results disappear when switching to the search screen

## Testing
- `bash scripts/install_tests.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e486e46f48333adec3205914b3e80